### PR TITLE
Use rayons fork join model in pq

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1225,6 +1225,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1454,6 +1463,7 @@ version = "0.1.0"
 dependencies = [
  "cc",
  "image",
+ "num_threads",
  "permutation_iterator",
  "rand 0.8.5",
  "rayon",

--- a/quantization/Cargo.toml
+++ b/quantization/Cargo.toml
@@ -16,3 +16,6 @@ permutation_iterator = "0.1.2"
 rand = "0.8.5"
 image = { version = "0.24.5", optional = true }
 rayon = "1.7.0"
+
+[dev-dependencies]
+num_threads = "0.1.6"

--- a/quantization/src/encoded_vectors_pq.rs
+++ b/quantization/src/encoded_vectors_pq.rs
@@ -159,8 +159,7 @@ impl<TStorage: EncodedStorage> EncodedVectorsPQ<TStorage> {
         condvars[0].notify(); // Allow first thread to use storage
 
         for thread_index in 0..max_threads {
-            // Thread process vectors `N` that `N % thread_index == 0`.
-            // 
+            // Thread process vectors `N` that `(N + thread_index) % max_threads == 0`.
             let data = data.clone().skip(thread_index);
             let storage_builder = storage_builder.clone();
             let condvar = condvars[thread_index].clone();

--- a/quantization/src/encoded_vectors_pq.rs
+++ b/quantization/src/encoded_vectors_pq.rs
@@ -166,9 +166,8 @@ impl<TStorage: EncodedStorage> EncodedVectorsPQ<TStorage> {
             let next_condvar = condvars[(thread_index + 1) % max_threads].clone();
 
             scope.spawn(move |_| {
-                let mut encoded_vector = Vec::new();
+                let mut encoded_vector = Vec::with_capacity(vector_division.len());
                 for vector in data.step_by(max_threads) {
-                    encoded_vector.clear();
                     Self::encode_vector(vector, vector_division, centroids, &mut encoded_vector);
                     // wait for permission from prev thread to use storage
                     let is_disconnected = condvar.wait();
@@ -205,6 +204,7 @@ impl<TStorage: EncodedStorage> EncodedVectorsPQ<TStorage> {
         centroids: &[Vec<f32>],
         encoded_vector: &mut Vec<u8>,
     ) {
+        encoded_vector.clear();
         for range in vector_division {
             let subvector_data = &vector_data[range.clone()];
             let mut min_distance = f32::MAX;

--- a/quantization/src/lib.rs
+++ b/quantization/src/lib.rs
@@ -6,6 +6,7 @@ pub mod kmeans;
 pub mod quantile;
 
 use std::fmt::Display;
+use std::sync::Arc;
 use std::sync::Condvar;
 use std::sync::Mutex;
 
@@ -33,24 +34,38 @@ impl Display for EncodingError {
     }
 }
 
+#[derive(Default, PartialEq, Clone, Copy)]
+enum ConditionalVariableState {
+    #[default]
+    Waiting,
+    Notified,
+}
+
 // ConditionalVariable is a wrapper around a mutex and a condvar
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct ConditionalVariable {
-    mutex: Mutex<bool>,
-    condvar: Condvar,
+    mutex: Arc<Mutex<ConditionalVariableState>>,
+    condvar: Arc<Condvar>,
 }
 
 impl ConditionalVariable {
-    pub fn wait(&self) {
+    pub fn wait(&self) -> bool {
         let mut guard = self.mutex.lock().unwrap();
-        while !*guard {
+        while *guard == ConditionalVariableState::Waiting && Arc::strong_count(&self.mutex) > 1 {
             guard = self.condvar.wait(guard).unwrap();
         }
-        *guard = false;
+        *guard = ConditionalVariableState::Waiting;
+        Arc::strong_count(&self.mutex) == 1
     }
 
     pub fn notify(&self) {
-        *self.mutex.lock().unwrap() = true;
-        self.condvar.notify_one();
+        *self.mutex.lock().unwrap() = ConditionalVariableState::Notified;
+        self.condvar.notify_all();
+    }
+}
+
+impl Drop for ConditionalVariable {
+    fn drop(&mut self) {
+        self.condvar.notify_all();
     }
 }

--- a/quantization/tests/test_pq.rs
+++ b/quantization/tests/test_pq.rs
@@ -3,6 +3,8 @@ mod metrics;
 
 #[cfg(test)]
 mod tests {
+    use std::{sync::atomic::AtomicUsize, time::Duration};
+
     use quantization::{
         encoded_vectors::{DistanceType, EncodedVectors, VectorParameters},
         encoded_vectors_pq::EncodedVectorsPQ,
@@ -200,6 +202,60 @@ mod tests {
             let score = encoded.score_internal(0, i as u32);
             let orginal_score = -dot_similarity(&vector_data[0], &vector_data[i]);
             assert!((score - orginal_score).abs() < ERROR);
+        }
+    }
+
+    #[test]
+    fn test_encode_panic() {
+        let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+        let mut vector_data: Vec<Vec<f32>> = Vec::new();
+        for _ in 0..VECTORS_COUNT {
+            let vector: Vec<f32> = (0..VECTOR_DIM).map(|_| rng.gen()).collect();
+            vector_data.push(vector);
+        }
+
+        for i in 0.. {
+            let counter = AtomicUsize::new(0);
+            let panic_index = i * VECTORS_COUNT / 3;
+
+            let start_num_threads = num_threads::num_threads();
+            let vector_data = vector_data.clone();
+            let result = std::thread::spawn(move || {
+                EncodedVectorsPQ::encode(
+                    vector_data.iter().map(|v| {
+                        let cnt = counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        if cnt == panic_index {
+                            panic!("test panic")
+                        }
+                        if cnt > panic_index {
+                            std::thread::sleep(Duration::from_micros(100));
+                        }
+                        v.as_slice()
+                    }),
+                    Vec::<u8>::new(),
+                    &VectorParameters {
+                        dim: VECTOR_DIM,
+                        count: VECTORS_COUNT,
+                        distance_type: DistanceType::Dot,
+                        invert: false,
+                    },
+                    1,
+                    5,
+                )
+                .unwrap()
+            })
+            .join();
+
+            if result.is_ok() {
+                // no panic, panic_index is too big, all panic cases are handled
+                return;
+            }
+
+            // some time required to finish encoding threads
+            std::thread::sleep(Duration::from_millis(50));
+
+            // check that all threads are finished
+            assert!(num_threads::num_threads() == start_num_threads);
         }
     }
 }

--- a/quantization/tests/test_pq.rs
+++ b/quantization/tests/test_pq.rs
@@ -205,6 +205,10 @@ mod tests {
         }
     }
 
+    // ignore this test because it requires long time
+    // this test should be started separately of with `--test-threads=1` flag
+    // because `num_threads::num_threads()` is used to check that all encode threads finished
+    #[ignore]
     #[test]
     fn test_encode_panic() {
         let mut rng = rand::rngs::StdRng::seed_from_u64(42);
@@ -228,6 +232,7 @@ mod tests {
                             panic!("test panic")
                         }
                         if cnt > panic_index {
+                            // after panic add start sleeping to simulate large amount of data
                             std::thread::sleep(Duration::from_micros(100));
                         }
                         v.as_slice()
@@ -256,6 +261,8 @@ mod tests {
 
             // check that all threads are finished
             assert!(num_threads::num_threads() == start_num_threads);
+
+            println!("Finished iteration {i}");
         }
     }
 }


### PR DESCRIPTION
Parallel PQ data encoding using `rayon` crate.

`rayon` provides fork-join model https://docs.rs/rayon/latest/rayon/fn.scope.html.

While this PR, N threads for data processing is created. Each thread number `thread_index` process all vectors `i` that `(i + thread_index) % max_threads == 0`. Encoding result is protected by conditional variables that implements ordered access (see more in comments).