### PR TITLE
Update Cargo.toml, specify license and other things

### DIFF
--- a/demos/Cargo.toml
+++ b/demos/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "demos"
 version = "0.1.0"
+license = "Apache-2.0"
 edition = "2021"
 
 [dev-dependencies]

--- a/demos/Cargo.toml
+++ b/demos/Cargo.toml
@@ -1,6 +1,10 @@
 [package]
 name = "demos"
 version = "0.1.0"
+authors = [
+    "Ivan Pleshkov <pleshkov.ivan@gmail.com>",
+    "Qdrant Team <info@qdrant.tech>",
+]
 license = "Apache-2.0"
 edition = "2021"
 

--- a/demos/Cargo.toml
+++ b/demos/Cargo.toml
@@ -6,6 +6,8 @@ authors = [
     "Qdrant Team <info@qdrant.tech>",
 ]
 license = "Apache-2.0"
+homepage = "https://qdrant.tech/"
+repository = "https://github.com/qdrant/quantization"
 edition = "2021"
 
 [dev-dependencies]

--- a/quantization/Cargo.toml
+++ b/quantization/Cargo.toml
@@ -6,6 +6,8 @@ authors = [
     "Qdrant Team <info@qdrant.tech>",
 ]
 license = "Apache-2.0"
+homepage = "https://qdrant.tech/"
+repository = "https://github.com/qdrant/quantization"
 edition = "2021"
 
 [features]

--- a/quantization/Cargo.toml
+++ b/quantization/Cargo.toml
@@ -1,6 +1,10 @@
 [package]
 name = "quantization"
 version = "0.1.0"
+authors = [
+    "Ivan Pleshkov <pleshkov.ivan@gmail.com>",
+    "Qdrant Team <info@qdrant.tech>",
+]
 license = "Apache-2.0"
 edition = "2021"
 

--- a/quantization/Cargo.toml
+++ b/quantization/Cargo.toml
@@ -2,7 +2,7 @@
 name = "quantization"
 version = "0.1.0"
 authors = [
-    "Ivan Pleshkov <pleshkov.ivan@gmail.com>",
+    "Ivan Pleshkov <ivan.pleshkov@qdrant.tech>",
     "Qdrant Team <info@qdrant.tech>",
 ]
 license = "Apache-2.0"

--- a/quantization/Cargo.toml
+++ b/quantization/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "quantization"
 version = "0.1.0"
+license = "Apache-2.0"
 edition = "2021"
 
 [features]


### PR DESCRIPTION
This updates the `Cargo.toml` definitions to specify the usage of Apache 2.0 in SPDX format.

Depends on: https://github.com/qdrant/quantization/pull/15
Recommended by: https://github.com/qdrant/wal/issues/49#issuecomment-1557650475

Along with it this also:
- updates the authors list
- adds README, homepage and repository links