### PR TITLE
Scalar quantization quantile interval bug

### DIFF
--- a/quantization/src/quantile.rs
+++ b/quantization/src/quantile.rs
@@ -22,7 +22,7 @@ pub(crate) fn find_quantile_interval<'a>(
     count: usize,
     quantile: f32,
 ) -> Option<(f32, f32)> {
-    if count < 127 {
+    if count < 127 || quantile >= 1.0 {
         return None;
     }
 
@@ -44,10 +44,15 @@ pub(crate) fn find_quantile_interval<'a>(
     }
 
     let data_slice_len = data_slice.len();
+    if data_slice_len < 4 {
+        return None;
+    }
+
     let cut_index = std::cmp::min(
-        (data_slice.len() - 1) / 2,
+        (data_slice_len - 1) / 2,
         (slice_size as f32 * (1.0 - quantile) / 2.0) as usize,
     );
+    let cut_index = std::cmp::max(cut_index, 1);
     let comparator = |a: &f32, b: &f32| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal);
     let (selected_values, _, _) =
         data_slice.select_nth_unstable_by(data_slice_len - cut_index, comparator);


### PR DESCRIPTION
In scalar quantization for almost `1.0` quantile values like `0.9999999` panic may occur with stacktrace
```
       7: core::slice::sort::partition_at_index
                 at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/core/src/slice/sort.rs:999:9
       8: core::slice::<impl [T]>::select_nth_unstable_by
                 at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/core/src/slice/mod.rs:2834:9
       9: quantization::quantile::find_quantile_interval
                 at /home/generall/.cargo/git/checkouts/quantization-e4ab6fc511580078/c93556c/quantization/src/quantile.rs:53:9
      10: quantization::encoded_vectors_u8::EncodedVectorsU8<TStorage>::encode
                 at /home/generall/.cargo/git/checkouts/quantization-e4ab6fc511580078/c93556c/quantization/src/encoded_vectors_u8.rs:59:39
      11: segment::vector_storage::quantized::quantized_vectors::QuantizedVectors::crate_scalar
                 at ./lib/segment/src/vector_storage/quantized/quantized_vectors.rs:250:50
      12: segment::vector_storage::quantized::quantized_vectors::QuantizedVectors::create
                 at ./lib/segment/src/vector_storage/quantized/quantized_vectors.rs:142:19
```