### PR TITLE
AsRef slice for encoding input

### DIFF
--- a/demos/benches/binary.rs
+++ b/demos/benches/binary.rs
@@ -35,7 +35,7 @@ fn binary_bench(c: &mut Criterion) {
     }
 
     let encoded = EncodedVectorsBin::encode(
-        vectors.iter().map(|v| v.as_slice()),
+        vectors.iter(),
         Vec::<u8>::new(),
         &VectorParameters {
             dim: vector_dim,

--- a/demos/src/ann_benchmark_data.rs
+++ b/demos/src/ann_benchmark_data.rs
@@ -199,7 +199,7 @@ impl AnnBenchmarkData {
         }
     }
 
-    fn print_timings(timings: &mut Vec<f64>) {
+    fn print_timings(timings: &mut [f64]) {
         if timings.is_empty() {
             return;
         }

--- a/demos/src/basic.rs
+++ b/demos/src/basic.rs
@@ -22,7 +22,7 @@ fn main() {
     let query: Vec<f32> = (0..vector_dim).map(|_| rng.gen()).collect();
 
     let encoded = EncodedVectorsU8::encode(
-        vector_data.iter().map(|v| v.as_slice()),
+        vector_data.iter(),
         Vec::<u8>::new(),
         &VectorParameters {
             dim: vector_dim,

--- a/quantization/src/encoded_vectors.rs
+++ b/quantization/src/encoded_vectors.rs
@@ -45,11 +45,12 @@ impl DistanceType {
 }
 
 pub(crate) fn validate_vector_parameters<'a>(
-    data: impl Iterator<Item = &'a [f32]>,
+    data: impl Iterator<Item = impl AsRef<[f32]> + 'a> + Clone,
     vector_parameters: &VectorParameters,
 ) -> Result<(), EncodingError> {
     let mut count = 0;
     for vector in data {
+        let vector = vector.as_ref();
         if vector.len() != vector_parameters.dim {
             return Err(EncodingError::ArgumentsError(format!(
                 "Vector length {} does not match vector parameters dim {}",

--- a/quantization/src/encoded_vectors_binary.rs
+++ b/quantization/src/encoded_vectors_binary.rs
@@ -27,7 +27,7 @@ struct Metadata {
 
 impl<TStorage: EncodedStorage> EncodedVectorsBin<TStorage> {
     pub fn encode<'a>(
-        orig_data: impl Iterator<Item = &'a [f32]> + Clone,
+        orig_data: impl Iterator<Item = impl AsRef<[f32]> + 'a> + Clone,
         mut storage_builder: impl EncodedStorageBuilder<TStorage>,
         vector_parameters: &VectorParameters,
         stop_condition: impl Fn() -> bool,
@@ -39,7 +39,7 @@ impl<TStorage: EncodedStorage> EncodedVectorsBin<TStorage> {
                 return Err(EncodingError::Stopped);
             }
 
-            let encoded_vector = Self::_encode_vector(vector);
+            let encoded_vector = Self::_encode_vector(vector.as_ref());
             let encoded_vector_slice = encoded_vector.encoded_vector.as_slice();
             let bytes = transmute_to_u8_slice(encoded_vector_slice);
             storage_builder.push_vector_data(bytes);

--- a/quantization/src/encoded_vectors_pq.rs
+++ b/quantization/src/encoded_vectors_pq.rs
@@ -343,7 +343,7 @@ impl<TStorage: EncodedStorage> EncodedVectorsPQ<TStorage> {
 
     #[cfg(feature = "dump_image")]
     fn dump_to_image<'a>(
-        data: impl Iterator<Item = &'a [f32]> + Clone,
+        data: impl Iterator<Item = impl AsRef<[f32]> + 'a> + Clone,
         storage: &TStorage,
         centroids: &[Vec<f32>],
         vector_division: &[Range<usize>],
@@ -370,6 +370,7 @@ impl<TStorage: EncodedStorage> EncodedVectorsPQ<TStorage> {
             }
 
             for (i, vector_data) in data.clone().enumerate() {
+                let vector_data = vector_data.as_ref();
                 let subvector_data = &vector_data[range.clone()];
                 let centroid_index =
                     storage.get_vector_data(i, vector_division.len())[range_i] as usize;

--- a/quantization/src/encoded_vectors_u8.rs
+++ b/quantization/src/encoded_vectors_u8.rs
@@ -32,7 +32,7 @@ struct Metadata {
 
 impl<TStorage: EncodedStorage> EncodedVectorsU8<TStorage> {
     pub fn encode<'a>(
-        orig_data: impl Iterator<Item = &'a [f32]> + Clone,
+        orig_data: impl Iterator<Item = impl AsRef<[f32]> + 'a> + Clone,
         mut storage_builder: impl EncodedStorageBuilder<TStorage>,
         vector_parameters: &VectorParameters,
         quantile: Option<f32>,
@@ -77,7 +77,7 @@ impl<TStorage: EncodedStorage> EncodedVectorsU8<TStorage> {
 
             let mut encoded_vector = Vec::with_capacity(actual_dim + std::mem::size_of::<f32>());
             encoded_vector.extend_from_slice(&f32::default().to_ne_bytes());
-            for &value in vector {
+            for &value in vector.as_ref() {
                 let encoded = Self::f32_to_u8(value, alpha, offset);
                 encoded_vector.push(encoded);
             }
@@ -218,7 +218,9 @@ impl<TStorage: EncodedStorage> EncodedVectorsU8<TStorage> {
         }
     }
 
-    fn find_alpha_offset_size_dim<'a>(orig_data: impl Iterator<Item = &'a [f32]>) -> (f32, f32) {
+    fn find_alpha_offset_size_dim<'a>(
+        orig_data: impl Iterator<Item = impl AsRef<[f32]> + 'a> + Clone,
+    ) -> (f32, f32) {
         let (min, max) = find_min_max_from_iter(orig_data);
         Self::alpha_offset_from_min_max(min, max)
     }

--- a/quantization/src/quantile.rs
+++ b/quantization/src/quantile.rs
@@ -2,9 +2,11 @@ use permutation_iterator::Permutor;
 
 pub const QUANTILE_SAMPLE_SIZE: usize = 100_000;
 
-pub(crate) fn find_min_max_from_iter<'a>(iter: impl Iterator<Item = &'a [f32]>) -> (f32, f32) {
+pub(crate) fn find_min_max_from_iter<'a>(
+    iter: impl Iterator<Item = impl AsRef<[f32]> + 'a> + Clone,
+) -> (f32, f32) {
     iter.fold((f32::MAX, f32::MIN), |(mut min, mut max), vector| {
-        for &value in vector {
+        for &value in vector.as_ref() {
             if value < min {
                 min = value;
             }
@@ -17,7 +19,7 @@ pub(crate) fn find_min_max_from_iter<'a>(iter: impl Iterator<Item = &'a [f32]>) 
 }
 
 pub(crate) fn find_quantile_interval<'a>(
-    vector_data: impl Iterator<Item = &'a [f32]>,
+    vector_data: impl Iterator<Item = impl AsRef<[f32]> + 'a> + Clone,
     dim: usize,
     count: usize,
     quantile: f32,
@@ -35,7 +37,7 @@ pub(crate) fn find_quantile_interval<'a>(
     let mut selected_index: usize = 0;
     for (vector_index, vector_data) in vector_data.into_iter().enumerate() {
         if vector_index == selected_vectors[selected_index] {
-            data_slice.extend_from_slice(vector_data);
+            data_slice.extend_from_slice(vector_data.as_ref());
             selected_index += 1;
             if selected_index == slice_size {
                 break;

--- a/quantization/src/utils.rs
+++ b/quantization/src/utils.rs
@@ -7,6 +7,19 @@ pub fn transmute_to_u8_slice<T>(v: &[T]) -> &[u8] {
 
 pub fn transmute_from_u8_to_slice<T>(data: &[u8]) -> &[T] {
     debug_assert_eq!(data.len() % size_of::<T>(), 0);
+
+    assert_eq!(
+        data.as_ptr().align_offset(mem::align_of::<T>()),
+        0,
+        "transmuting byte slice 0x{:p} into slice of {}: \
+         required alignment is {} bytes, \
+         byte slice misaligned by {} bytes",
+        data.as_ptr(),
+        std::any::type_name::<T>(),
+        mem::align_of::<T>(),
+        data.as_ptr().align_offset(mem::align_of::<T>()),
+    );
+
     let len = data.len() / size_of::<T>();
     let ptr = data.as_ptr() as *const T;
     unsafe { std::slice::from_raw_parts(ptr, len) }

--- a/quantization/tests/empty_storage.rs
+++ b/quantization/tests/empty_storage.rs
@@ -25,7 +25,7 @@ mod tests {
         let vector_data: Vec<Vec<f32>> = Default::default();
 
         let encoded = EncodedVectorsU8::encode(
-            vector_data.iter().map(|v| v.as_slice()),
+            vector_data.iter(),
             Vec::<u8>::new(),
             &vector_parameters,
             None,
@@ -62,7 +62,7 @@ mod tests {
         let vector_data: Vec<Vec<f32>> = Default::default();
 
         let encoded = EncodedVectorsPQ::encode(
-            vector_data.iter().map(|v| v.as_slice()),
+            vector_data.iter(),
             Vec::<u8>::new(),
             &vector_parameters,
             2,

--- a/quantization/tests/stop_condition.rs
+++ b/quantization/tests/stop_condition.rs
@@ -37,7 +37,7 @@ mod tests {
 
         assert!(
             EncodedVectorsU8::encode(
-                (0..vector_parameters.count).map(|_| zero_vector.as_slice()),
+                (0..vector_parameters.count).map(|_| &zero_vector),
                 Vec::<u8>::new(),
                 &vector_parameters,
                 None,
@@ -73,7 +73,7 @@ mod tests {
 
         assert!(
             EncodedVectorsPQ::encode(
-                (0..vector_parameters.count).map(|_| zero_vector.as_slice()),
+                (0..vector_parameters.count).map(|_| &zero_vector),
                 Vec::<u8>::new(),
                 &vector_parameters,
                 2,

--- a/quantization/tests/test_avx2.rs
+++ b/quantization/tests/test_avx2.rs
@@ -27,7 +27,7 @@ mod tests {
         let query: Vec<f32> = (0..vector_dim).map(|_| rng.gen()).collect();
 
         let encoded = EncodedVectorsU8::encode(
-            vector_data.iter().map(|v| v.as_slice()),
+            vector_data.iter(),
             Vec::<u8>::new(),
             &VectorParameters {
                 dim: vector_dim,
@@ -64,7 +64,7 @@ mod tests {
         let query: Vec<f32> = (0..vector_dim).map(|_| rng.gen()).collect();
 
         let encoded = EncodedVectorsU8::encode(
-            vector_data.iter().map(|v| v.as_slice()),
+            vector_data.iter(),
             Vec::<u8>::new(),
             &VectorParameters {
                 dim: vector_dim,
@@ -101,7 +101,7 @@ mod tests {
         let query: Vec<f32> = (0..vector_dim).map(|_| rng.gen_range(-1.0..=1.0)).collect();
 
         let encoded = EncodedVectorsU8::encode(
-            vector_data.iter().map(|v| v.as_slice()),
+            vector_data.iter(),
             Vec::<u8>::new(),
             &VectorParameters {
                 dim: vector_dim,

--- a/quantization/tests/test_binary.rs
+++ b/quantization/tests/test_binary.rs
@@ -38,7 +38,7 @@ mod tests {
         }
 
         let encoded = EncodedVectorsBin::encode(
-            vector_data.iter().map(|v| v.as_slice()),
+            vector_data.iter(),
             Vec::<u8>::new(),
             &VectorParameters {
                 dim: vector_dim,
@@ -74,7 +74,7 @@ mod tests {
         }
 
         let encoded = EncodedVectorsBin::encode(
-            vector_data.iter().map(|v| v.as_slice()),
+            vector_data.iter(),
             Vec::<u8>::new(),
             &VectorParameters {
                 dim: vector_dim,
@@ -110,7 +110,7 @@ mod tests {
         }
 
         let encoded = EncodedVectorsBin::encode(
-            vector_data.iter().map(|v| v.as_slice()),
+            vector_data.iter(),
             Vec::<u8>::new(),
             &VectorParameters {
                 dim: vector_dim,
@@ -143,7 +143,7 @@ mod tests {
         }
 
         let encoded = EncodedVectorsBin::encode(
-            vector_data.iter().map(|v| v.as_slice()),
+            vector_data.iter(),
             Vec::<u8>::new(),
             &VectorParameters {
                 dim: vector_dim,
@@ -175,7 +175,7 @@ mod tests {
         }
 
         let encoded = EncodedVectorsBin::encode(
-            vector_data.iter().map(|v| v.as_slice()),
+            vector_data.iter(),
             Vec::<u8>::new(),
             &VectorParameters {
                 dim: vector_dim,
@@ -226,7 +226,7 @@ mod tests {
         }
 
         let encoded = EncodedVectorsBin::encode(
-            vector_data.iter().map(|v| v.as_slice()),
+            vector_data.iter(),
             Vec::<u8>::new(),
             &VectorParameters {
                 dim: vector_dim,
@@ -277,7 +277,7 @@ mod tests {
         }
 
         let encoded = EncodedVectorsBin::encode(
-            vector_data.iter().map(|v| v.as_slice()),
+            vector_data.iter(),
             Vec::<u8>::new(),
             &VectorParameters {
                 dim: vector_dim,
@@ -325,7 +325,7 @@ mod tests {
         }
 
         let encoded = EncodedVectorsBin::encode(
-            vector_data.iter().map(|v| v.as_slice()),
+            vector_data.iter(),
             Vec::<u8>::new(),
             &VectorParameters {
                 dim: vector_dim,
@@ -373,7 +373,7 @@ mod tests {
         }
 
         let encoded = EncodedVectorsBin::encode(
-            vector_data.iter().map(|v| v.as_slice()),
+            vector_data.iter(),
             Vec::<u8>::new(),
             &VectorParameters {
                 dim: vector_dim,
@@ -424,7 +424,7 @@ mod tests {
         }
 
         let encoded = EncodedVectorsBin::encode(
-            vector_data.iter().map(|v| v.as_slice()),
+            vector_data.iter(),
             Vec::<u8>::new(),
             &VectorParameters {
                 dim: vector_dim,
@@ -475,7 +475,7 @@ mod tests {
         }
 
         let encoded = EncodedVectorsBin::encode(
-            vector_data.iter().map(|v| v.as_slice()),
+            vector_data.iter(),
             Vec::<u8>::new(),
             &VectorParameters {
                 dim: vector_dim,
@@ -523,7 +523,7 @@ mod tests {
         }
 
         let encoded = EncodedVectorsBin::encode(
-            vector_data.iter().map(|v| v.as_slice()),
+            vector_data.iter(),
             Vec::<u8>::new(),
             &VectorParameters {
                 dim: vector_dim,

--- a/quantization/tests/test_neon.rs
+++ b/quantization/tests/test_neon.rs
@@ -27,7 +27,7 @@ mod tests {
         let query: Vec<f32> = (0..vector_dim).map(|_| rng.gen()).collect();
 
         let encoded = EncodedVectorsU8::encode(
-            vector_data.iter().map(|v| v.as_slice()),
+            vector_data.iter(),
             Vec::<u8>::new(),
             &VectorParameters {
                 dim: vector_dim,
@@ -63,7 +63,7 @@ mod tests {
         let query: Vec<f32> = (0..vector_dim).map(|_| rng.gen()).collect();
 
         let encoded = EncodedVectorsU8::encode(
-            vector_data.iter().map(|v| v.as_slice()),
+            vector_data.iter(),
             Vec::<u8>::new(),
             &VectorParameters {
                 dim: vector_dim,
@@ -99,7 +99,7 @@ mod tests {
         let query: Vec<f32> = (0..vector_dim).map(|_| rng.gen()).collect();
 
         let encoded = EncodedVectorsU8::encode(
-            vector_data.iter().map(|v| v.as_slice()),
+            vector_data.iter(),
             Vec::<u8>::new(),
             &VectorParameters {
                 dim: vector_dim,

--- a/quantization/tests/test_pq.rs
+++ b/quantization/tests/test_pq.rs
@@ -27,7 +27,7 @@ mod tests {
         let query: Vec<_> = (0..VECTOR_DIM).map(|_| rng.gen()).collect();
 
         let encoded = EncodedVectorsPQ::encode(
-            vector_data.iter().map(Vec::as_slice),
+            vector_data.iter(),
             vec![],
             &VectorParameters {
                 dim: VECTOR_DIM,
@@ -59,7 +59,7 @@ mod tests {
         let query: Vec<_> = (0..VECTOR_DIM).map(|_| rng.gen()).collect();
 
         let encoded = EncodedVectorsPQ::encode(
-            vector_data.iter().map(Vec::as_slice),
+            vector_data.iter(),
             vec![],
             &VectorParameters {
                 dim: VECTOR_DIM,
@@ -91,7 +91,7 @@ mod tests {
         let query: Vec<_> = (0..VECTOR_DIM).map(|_| rng.gen()).collect();
 
         let encoded = EncodedVectorsPQ::encode(
-            vector_data.iter().map(Vec::as_slice),
+            vector_data.iter(),
             vec![],
             &VectorParameters {
                 dim: VECTOR_DIM,
@@ -123,7 +123,7 @@ mod tests {
         let query: Vec<_> = (0..VECTOR_DIM).map(|_| rng.gen()).collect();
 
         let encoded = EncodedVectorsPQ::encode(
-            vector_data.iter().map(Vec::as_slice),
+            vector_data.iter(),
             vec![],
             &VectorParameters {
                 dim: VECTOR_DIM,
@@ -155,7 +155,7 @@ mod tests {
         let query: Vec<_> = (0..VECTOR_DIM).map(|_| rng.gen()).collect();
 
         let encoded = EncodedVectorsPQ::encode(
-            vector_data.iter().map(Vec::as_slice),
+            vector_data.iter(),
             vec![],
             &VectorParameters {
                 dim: VECTOR_DIM,
@@ -187,7 +187,7 @@ mod tests {
         let query: Vec<_> = (0..VECTOR_DIM).map(|_| rng.gen()).collect();
 
         let encoded = EncodedVectorsPQ::encode(
-            vector_data.iter().map(Vec::as_slice),
+            vector_data.iter(),
             vec![],
             &VectorParameters {
                 dim: VECTOR_DIM,
@@ -218,7 +218,7 @@ mod tests {
         }
 
         let encoded = EncodedVectorsPQ::encode(
-            vector_data.iter().map(Vec::as_slice),
+            vector_data.iter(),
             vec![],
             &VectorParameters {
                 dim: VECTOR_DIM,
@@ -248,7 +248,7 @@ mod tests {
         }
 
         let encoded = EncodedVectorsPQ::encode(
-            vector_data.iter().map(Vec::as_slice),
+            vector_data.iter(),
             vec![],
             &VectorParameters {
                 dim: VECTOR_DIM,
@@ -298,7 +298,7 @@ mod tests {
                             // after panic add start sleeping to simulate large amount of data
                             std::thread::sleep(Duration::from_micros(100));
                         }
-                        v.as_slice()
+                        v
                     }),
                     vec![],
                     &VectorParameters {

--- a/quantization/tests/test_simple.rs
+++ b/quantization/tests/test_simple.rs
@@ -27,7 +27,7 @@ mod tests {
         let query: Vec<f32> = (0..vector_dim).map(|_| rng.gen()).collect();
 
         let encoded = EncodedVectorsU8::encode(
-            vector_data.iter().map(|v| v.as_slice()),
+            vector_data.iter(),
             Vec::<u8>::new(),
             &VectorParameters {
                 dim: vector_dim,
@@ -64,7 +64,7 @@ mod tests {
         let query: Vec<f32> = (0..vector_dim).map(|_| rng.gen::<f32>()).collect();
 
         let encoded = EncodedVectorsU8::encode(
-            vector_data.iter().map(|v| v.as_slice()),
+            vector_data.iter(),
             Vec::<u8>::new(),
             &VectorParameters {
                 dim: vector_dim,
@@ -101,7 +101,7 @@ mod tests {
         let query: Vec<f32> = (0..vector_dim).map(|_| rng.gen_range(-1.0..=1.0)).collect();
 
         let encoded = EncodedVectorsU8::encode(
-            vector_data.iter().map(|v| v.as_slice()),
+            vector_data.iter(),
             Vec::<u8>::new(),
             &VectorParameters {
                 dim: vector_dim,
@@ -138,7 +138,7 @@ mod tests {
         let query: Vec<f32> = (0..vector_dim).map(|_| rng.gen()).collect();
 
         let encoded = EncodedVectorsU8::encode(
-            vector_data.iter().map(|v| v.as_slice()),
+            vector_data.iter(),
             Vec::<u8>::new(),
             &VectorParameters {
                 dim: vector_dim,
@@ -175,7 +175,7 @@ mod tests {
         let query: Vec<f32> = (0..vector_dim).map(|_| rng.gen::<f32>()).collect();
 
         let encoded = EncodedVectorsU8::encode(
-            vector_data.iter().map(|v| v.as_slice()),
+            vector_data.iter(),
             Vec::<u8>::new(),
             &VectorParameters {
                 dim: vector_dim,
@@ -212,7 +212,7 @@ mod tests {
         let query: Vec<f32> = (0..vector_dim).map(|_| rng.gen_range(-1.0..=1.0)).collect();
 
         let encoded = EncodedVectorsU8::encode(
-            vector_data.iter().map(|v| v.as_slice()),
+            vector_data.iter(),
             Vec::<u8>::new(),
             &VectorParameters {
                 dim: vector_dim,
@@ -248,7 +248,7 @@ mod tests {
         }
 
         let encoded = EncodedVectorsU8::encode(
-            vector_data.iter().map(|v| v.as_slice()),
+            vector_data.iter(),
             Vec::<u8>::new(),
             &VectorParameters {
                 dim: vector_dim,
@@ -283,7 +283,7 @@ mod tests {
         }
 
         let encoded = EncodedVectorsU8::encode(
-            vector_data.iter().map(|v| v.as_slice()),
+            vector_data.iter(),
             Vec::<u8>::new(),
             &VectorParameters {
                 dim: vector_dim,
@@ -318,7 +318,7 @@ mod tests {
         let query: Vec<f32> = (0..vector_dim).map(|_| rng.gen()).collect();
 
         let encoded = EncodedVectorsU8::encode(
-            vector_data.iter().map(|v| v.as_slice()),
+            vector_data.iter(),
             Vec::<u8>::new(),
             &VectorParameters {
                 dim: vector_dim,

--- a/quantization/tests/test_sse.rs
+++ b/quantization/tests/test_sse.rs
@@ -27,7 +27,7 @@ mod tests {
         let query: Vec<f32> = (0..vector_dim).map(|_| rng.gen()).collect();
 
         let encoded = EncodedVectorsU8::encode(
-            vector_data.iter().map(|v| v.as_slice()),
+            vector_data.iter(),
             Vec::<u8>::new(),
             &VectorParameters {
                 dim: vector_dim,
@@ -64,7 +64,7 @@ mod tests {
         let query: Vec<f32> = (0..vector_dim).map(|_| rng.gen()).collect();
 
         let encoded = EncodedVectorsU8::encode(
-            vector_data.iter().map(|v| v.as_slice()),
+            vector_data.iter(),
             Vec::<u8>::new(),
             &VectorParameters {
                 dim: vector_dim,
@@ -101,7 +101,7 @@ mod tests {
         let query: Vec<f32> = (0..vector_dim).map(|_| rng.gen()).collect();
 
         let encoded = EncodedVectorsU8::encode(
-            vector_data.iter().map(|v| v.as_slice()),
+            vector_data.iter(),
             Vec::<u8>::new(),
             &VectorParameters {
                 dim: vector_dim,


### PR DESCRIPTION
Exchange arguments `impl Iterator<Item = &'a [f32]>` into `impl Iterator<Item = impl AsRef<[f32]> + 'a>`.
It allows to use non-slice types for encoder. Like `Vec<f32>` or `Cow<'a, [f32]>`