### PR TITLE
Bq with u8 alignment support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1224,9 +1224,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
@@ -1480,6 +1480,7 @@ version = "0.1.0"
 dependencies = [
  "cc",
  "image",
+ "num-traits",
  "num_threads",
  "permutation_iterator",
  "rand 0.8.5",

--- a/demos/benches/binary.rs
+++ b/demos/benches/binary.rs
@@ -108,6 +108,7 @@ fn binary_bench(c: &mut Criterion) {
         });
     });
 
+    #[cfg(target_arch = "x86_64")]
     group.bench_function("score DOT random access", |b| {
         b.iter(|| {
             let mut _s = 0.0;

--- a/demos/benches/binary.rs
+++ b/demos/benches/binary.rs
@@ -34,7 +34,7 @@ fn binary_bench(c: &mut Criterion) {
         vectors.push(vector);
     }
 
-    let encoded = EncodedVectorsBin::encode(
+    let encoded_u128 = EncodedVectorsBin::<u128, _>::encode(
         vectors.iter(),
         Vec::<u8>::new(),
         &VectorParameters {
@@ -48,13 +48,13 @@ fn binary_bench(c: &mut Criterion) {
     .unwrap();
 
     let query = generate_vector(vector_dim, &mut rng);
-    let encoded_query = encoded.encode_query(&query);
+    let encoded_query = encoded_u128.encode_query(&query);
 
-    group.bench_function("score binary linear access", |b| {
+    group.bench_function("score binary linear access u128", |b| {
         b.iter(|| {
             let mut _s = 0.0;
             for i in 0..vectors_count as u32 {
-                _s = encoded.score_point(&encoded_query, i);
+                _s = encoded_u128.score_point(&encoded_query, i);
             }
         });
     });
@@ -62,11 +62,48 @@ fn binary_bench(c: &mut Criterion) {
     let permutor = Permutor::new(vectors_count as u64);
     let permutation: Vec<u32> = permutor.map(|i| i as u32).collect();
 
-    group.bench_function("score binary random access", |b| {
+    group.bench_function("score binary random access u128", |b| {
         b.iter(|| {
             let mut _s = 0.0;
             for &i in &permutation {
-                _s = encoded.score_point(&encoded_query, i);
+                _s = encoded_u128.score_point(&encoded_query, i);
+            }
+        });
+    });
+
+    let encoded_u8 = EncodedVectorsBin::<u8, _>::encode(
+        vectors.iter(),
+        Vec::<u8>::new(),
+        &VectorParameters {
+            dim: vector_dim,
+            count: vectors_count,
+            distance_type: DistanceType::Dot,
+            invert: false,
+        },
+        || false,
+    )
+    .unwrap();
+
+    let query = generate_vector(vector_dim, &mut rng);
+    let encoded_query = encoded_u8.encode_query(&query);
+
+    group.bench_function("score binary linear access u8", |b| {
+        b.iter(|| {
+            let mut _s = 0.0;
+            for i in 0..vectors_count as u32 {
+                _s = encoded_u8.score_point(&encoded_query, i);
+            }
+        });
+    });
+
+    let permutor = Permutor::new(vectors_count as u64);
+    let permutation: Vec<u32> = permutor.map(|i| i as u32).collect();
+
+    group.bench_function("score binary random access u8", |b| {
+        b.iter(|| {
+            let mut _s = 0.0;
+            for &i in &permutation {
+                _s = encoded_u8.score_point(&encoded_query, i);
             }
         });
     });

--- a/quantization/Cargo.toml
+++ b/quantization/Cargo.toml
@@ -23,6 +23,7 @@ permutation_iterator = "0.1.2"
 rand = "0.8.5"
 image = { version = "0.24.5", optional = true }
 rayon = "1.7.0"
+num-traits = "0.2.19"
 
 [dev-dependencies]
 num_threads = "0.1.6"

--- a/quantization/cpp/neon.c
+++ b/quantization/cpp/neon.c
@@ -23,7 +23,7 @@ EXPORT float impl_score_dot_neon(
     return (float)vaddvq_u32(vaddq_u32(mul1, mul2));
 }
 
-EXPORT uint64_t impl_xor_popcnt_neon(
+EXPORT uint64_t impl_xor_popcnt_neon_uint64(
     const uint64_t* query_ptr,
     const uint64_t* vector_ptr,
     uint32_t count
@@ -31,7 +31,7 @@ EXPORT uint64_t impl_xor_popcnt_neon(
     const uint8_t* v_ptr = (const uint8_t*)vector_ptr;
     const uint8_t* q_ptr = (const uint8_t*)query_ptr;
     uint32x4_t result = vdupq_n_u32(0);
-    for (uint32_t _i = 0; _i < count / 2; _i++) {
+    for (uint32_t _i = 0; _i < count / 4; _i++) {
         uint8x16_t v1 = vld1q_u8(v_ptr);
         uint8x16_t q1 = vld1q_u8(q_ptr);
         uint8x16_t v2 = vld1q_u8(v_ptr + 16);
@@ -51,7 +51,7 @@ EXPORT uint64_t impl_xor_popcnt_neon(
         q_ptr += 32;
     }
 
-    if (count % 2 == 1) {
+    if (count % 4 != 0) {
         uint8x16_t v = vld1q_u8(v_ptr);
         uint8x16_t q = vld1q_u8(q_ptr);
         uint8x16_t x = veorq_u8(q, v);
@@ -63,6 +63,14 @@ EXPORT uint64_t impl_xor_popcnt_neon(
     }
 
     return (uint64_t)vaddvq_u32(result);
+}
+
+EXPORT uint64_t impl_xor_popcnt_neon_uint8(
+    const uint8_t* query_ptr,
+    const uint8_t* vector_ptr,
+    uint32_t count
+) {
+    return (uint64_t)0;
 }
 
 EXPORT float impl_score_l1_neon(

--- a/quantization/cpp/neon.c
+++ b/quantization/cpp/neon.c
@@ -30,11 +30,11 @@ EXPORT uint32_t impl_xor_popcnt_neon_uint128(
 ) {
     uint32x4_t result = vdupq_n_u32(0);
     for (uint32_t _i = 0; _i < count; _i++) {
-        uint8x16_t v1 = vld1q_u8(vector_ptr);
-        uint8x16_t q1 = vld1q_u8(query_ptr);
+        uint8x16_t v = vld1q_u8(vector_ptr);
+        uint8x16_t q = vld1q_u8(query_ptr);
 
-        uint8x16_t x1 = veorq_u8(q1, v1);
-        uint8x16_t popcnt = vcntq_u8(x1);
+        uint8x16_t x = veorq_u8(q, v);
+        uint8x16_t popcnt = vcntq_u8(x);
         uint8x8_t popcnt_low = vget_low_u8(popcnt);
         uint8x8_t popcnt_high = vget_high_u8(popcnt);
         uint16x8_t sum = vaddl_u8(popcnt_low, popcnt_high);
@@ -44,6 +44,26 @@ EXPORT uint32_t impl_xor_popcnt_neon_uint128(
         vector_ptr += 16;
     }
     return (uint32_t)vaddvq_u32(result);
+}
+
+EXPORT uint32_t impl_xor_popcnt_neon_uint64(
+    const uint8_t* query_ptr,
+    const uint8_t* vector_ptr,
+    uint32_t count
+) {
+    uint16x4_t result = vdup_n_u16(0);
+    for (uint32_t _i = 0; _i < count; _i++) {
+        uint8x8_t v = vld1_u8(vector_ptr);
+        uint8x8_t q = vld1_u8(query_ptr);
+
+        uint8x8_t x = veor_u8(q, v);
+        uint8x8_t popcnt = vcnt_u8(x);
+        result = vpadal_u8(result, popcnt);
+
+        query_ptr += 8;
+        vector_ptr += 8;
+    }
+    return (uint32_t)vaddv_u16(result);
 }
 
 EXPORT float impl_score_l1_neon(

--- a/quantization/cpp/neon.c
+++ b/quantization/cpp/neon.c
@@ -23,54 +23,27 @@ EXPORT float impl_score_dot_neon(
     return (float)vaddvq_u32(vaddq_u32(mul1, mul2));
 }
 
-EXPORT uint64_t impl_xor_popcnt_neon_uint64(
-    const uint64_t* query_ptr,
-    const uint64_t* vector_ptr,
-    uint32_t count
-) {
-    const uint8_t* v_ptr = (const uint8_t*)vector_ptr;
-    const uint8_t* q_ptr = (const uint8_t*)query_ptr;
-    uint32x4_t result = vdupq_n_u32(0);
-    for (uint32_t _i = 0; _i < count / 4; _i++) {
-        uint8x16_t v1 = vld1q_u8(v_ptr);
-        uint8x16_t q1 = vld1q_u8(q_ptr);
-        uint8x16_t v2 = vld1q_u8(v_ptr + 16);
-        uint8x16_t q2 = vld1q_u8(q_ptr + 16);
-
-        uint8x16_t x1 = veorq_u8(q1, v1);
-        uint8x16_t x2 = veorq_u8(q2, v2);
-        uint8x16_t popcnt1 = vcntq_u8(x1);
-        uint8x16_t popcnt2 = vcntq_u8(x2);
-        uint8x16_t popcnt = vaddq_u8(popcnt1, popcnt2);
-        uint8x8_t popcnt_low = vget_low_u8(popcnt);
-        uint8x8_t popcnt_high = vget_high_u8(popcnt);
-        uint16x8_t sum = vaddl_u8(popcnt_low, popcnt_high);
-        result = vpadalq_u16(result, sum);
-
-        v_ptr += 32;
-        q_ptr += 32;
-    }
-
-    if (count % 4 != 0) {
-        uint8x16_t v = vld1q_u8(v_ptr);
-        uint8x16_t q = vld1q_u8(q_ptr);
-        uint8x16_t x = veorq_u8(q, v);
-        uint8x16_t popcnt = vcntq_u8(x);
-        uint8x8_t popcnt_low = vget_low_u8(popcnt);
-        uint8x8_t popcnt_high = vget_high_u8(popcnt);
-        uint16x8_t sum = vaddl_u8(popcnt_low, popcnt_high);
-        result = vpadalq_u16(result, sum);
-    }
-
-    return (uint64_t)vaddvq_u32(result);
-}
-
-EXPORT uint64_t impl_xor_popcnt_neon_uint8(
+EXPORT uint32_t impl_xor_popcnt_neon_uint128(
     const uint8_t* query_ptr,
     const uint8_t* vector_ptr,
     uint32_t count
 ) {
-    return (uint64_t)0;
+    uint32x4_t result = vdupq_n_u32(0);
+    for (uint32_t _i = 0; _i < count; _i++) {
+        uint8x16_t v1 = vld1q_u8(vector_ptr);
+        uint8x16_t q1 = vld1q_u8(query_ptr);
+
+        uint8x16_t x1 = veorq_u8(q1, v1);
+        uint8x16_t popcnt = vcntq_u8(x1);
+        uint8x8_t popcnt_low = vget_low_u8(popcnt);
+        uint8x8_t popcnt_high = vget_high_u8(popcnt);
+        uint16x8_t sum = vaddl_u8(popcnt_low, popcnt_high);
+        result = vpadalq_u16(result, sum);
+
+        query_ptr += 16;
+        vector_ptr += 16;
+    }
+    return (uint32_t)vaddvq_u32(result);
 }
 
 EXPORT float impl_score_l1_neon(

--- a/quantization/cpp/sse.c
+++ b/quantization/cpp/sse.c
@@ -46,19 +46,40 @@ EXPORT float impl_score_dot_sse(
     return mul_scalar;
 }
 
-EXPORT uint64_t impl_xor_popcnt_sse(
+EXPORT uint32_t impl_xor_popcnt_sse_uint64(
     const uint64_t* query_ptr,
     const uint64_t* vector_ptr,
     uint32_t count
 ) {
-    const int64_t* v_ptr = (const int64_t*)vector_ptr;
-    const int64_t* q_ptr = (const int64_t*)query_ptr;
     int64_t result = 0;
-    for (uint32_t _i = 0; _i < 2 * count; _i++) {
-        uint64_t x = (*v_ptr) ^ (*q_ptr);
+    for (uint32_t _i = 0; _i < count; _i++) {
+        uint64_t x = (*vector_ptr) ^ (*query_ptr);
         result += _mm_popcnt_u64(x);
-        v_ptr++;
-        q_ptr++;
+        vector_ptr++;
+        query_ptr++;
+    }
+    return (uint32_t)result;
+}
+
+EXPORT uint32_t impl_xor_popcnt_sse_uint8(
+    const uint8_t* query_ptr,
+    const uint8_t* vector_ptr,
+    uint32_t count
+) {
+    int result = 0;
+    for (uint32_t _i = 0; _i < count / 4; _i++) {
+        const uint32_t* v_ptr = (const uint32_t*)vector_ptr;
+        const uint32_t* q_ptr = (const uint32_t*)query_ptr;
+        uint32_t x = (*v_ptr) ^ (*q_ptr);
+        result += _mm_popcnt_u32(x);
+        vector_ptr += 4;
+        query_ptr += 4;
+    }
+    for (uint32_t _i = 0; _i < count % 4; _i++) {
+        uint8_t x = (*vector_ptr) ^ (*query_ptr);
+        result += (int)__builtin_popcount(x);
+        vector_ptr++;
+        query_ptr++;
     }
     return (uint32_t)result;
 }

--- a/quantization/cpp/sse.c
+++ b/quantization/cpp/sse.c
@@ -46,17 +46,25 @@ EXPORT float impl_score_dot_sse(
     return mul_scalar;
 }
 
-EXPORT uint32_t impl_xor_popcnt_sse_uint64(
-    const uint64_t* query_ptr,
-    const uint64_t* vector_ptr,
+EXPORT uint32_t impl_xor_popcnt_sse_uint128(
+    const uint8_t* query_ptr,
+    const uint8_t* vector_ptr,
     uint32_t count
 ) {
     int64_t result = 0;
     for (uint32_t _i = 0; _i < count; _i++) {
-        uint64_t x = (*vector_ptr) ^ (*query_ptr);
-        result += _mm_popcnt_u64(x);
-        vector_ptr++;
-        query_ptr++;
+        const uint64_t* v_ptr_1 = (const uint64_t*)vector_ptr;
+        const uint64_t* q_ptr_1 = (const uint64_t*)query_ptr;
+        uint64_t x_1 = (*v_ptr_1) ^ (*q_ptr_1);
+        result += _mm_popcnt_u64(x_1);
+
+        const uint64_t* v_ptr_2 = v_ptr_1 + 1;
+        const uint64_t* q_ptr_2 = q_ptr_1 + 1;
+        uint64_t x_2 = (*v_ptr_2) ^ (*q_ptr_2);
+        result += _mm_popcnt_u64(x_2);
+
+        vector_ptr += 16;
+        query_ptr += 16;
     }
     return (uint32_t)result;
 }
@@ -68,9 +76,9 @@ EXPORT uint32_t impl_xor_popcnt_sse_uint8(
 ) {
     int result = 0;
     for (uint32_t _i = 0; _i < count / 4; _i++) {
-        const uint32_t* v_ptr = (const uint32_t*)vector_ptr;
-        const uint32_t* q_ptr = (const uint32_t*)query_ptr;
-        uint32_t x = (*v_ptr) ^ (*q_ptr);
+        uint32_t v = (*vector_ptr) | (*(vector_ptr + 1) << 8) | (*(vector_ptr + 2) << 16) | (*(vector_ptr + 3) << 24);
+        uint32_t q = (*query_ptr) | (*(query_ptr + 1) << 8) | (*(query_ptr + 2) << 16) | (*(query_ptr + 3) << 24);
+        uint32_t x = v ^ q;
         result += _mm_popcnt_u32(x);
         vector_ptr += 4;
         query_ptr += 4;

--- a/quantization/cpp/sse.c
+++ b/quantization/cpp/sse.c
@@ -69,25 +69,38 @@ EXPORT uint32_t impl_xor_popcnt_sse_uint128(
     return (uint32_t)result;
 }
 
-EXPORT uint32_t impl_xor_popcnt_sse_uint8(
+EXPORT uint32_t impl_xor_popcnt_sse_uint64(
+    const uint8_t* query_ptr,
+    const uint8_t* vector_ptr,
+    uint32_t count
+) {
+    int64_t result = 0;
+    for (uint32_t _i = 0; _i < count; _i++) {
+        const uint64_t* v_ptr = (const uint64_t*)vector_ptr;
+        const uint64_t* q_ptr = (const uint64_t*)query_ptr;
+        uint64_t x = (*v_ptr) ^ (*q_ptr);
+        result += _mm_popcnt_u64(x);
+
+        vector_ptr += 8;
+        query_ptr += 8;
+    }
+    return (uint32_t)result;
+}
+
+EXPORT uint32_t impl_xor_popcnt_sse_uint32(
     const uint8_t* query_ptr,
     const uint8_t* vector_ptr,
     uint32_t count
 ) {
     int result = 0;
-    for (uint32_t _i = 0; _i < count / 4; _i++) {
-        uint32_t v = (*vector_ptr) | (*(vector_ptr + 1) << 8) | (*(vector_ptr + 2) << 16) | (*(vector_ptr + 3) << 24);
-        uint32_t q = (*query_ptr) | (*(query_ptr + 1) << 8) | (*(query_ptr + 2) << 16) | (*(query_ptr + 3) << 24);
-        uint32_t x = v ^ q;
+    for (uint32_t _i = 0; _i < count; _i++) {
+        const uint32_t* v_ptr = (const uint32_t*)vector_ptr;
+        const uint32_t* q_ptr = (const uint32_t*)query_ptr;
+        uint32_t x = (*v_ptr) ^ (*q_ptr);
         result += _mm_popcnt_u32(x);
+
         vector_ptr += 4;
         query_ptr += 4;
-    }
-    for (uint32_t _i = 0; _i < count % 4; _i++) {
-        uint8_t x = (*vector_ptr) ^ (*query_ptr);
-        result += (int)__builtin_popcount(x);
-        vector_ptr++;
-        query_ptr++;
     }
     return (uint32_t)result;
 }

--- a/quantization/src/encoded_vectors_binary.rs
+++ b/quantization/src/encoded_vectors_binary.rs
@@ -90,10 +90,10 @@ impl BitsStoreType for u128 {
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         if is_x86_feature_detected!("sse4.2") {
             unsafe {
-                return impl_xor_popcnt_sse_uint64(
+                return impl_xor_popcnt_sse_uint128(
                     v1.as_ptr() as *const u64,
                     v2.as_ptr() as *const u64,
-                    2 * v1.len() as u32, // multiply by 2 because u128 contains 2 u64 elements
+                    v1.len() as u32,
                 ) as usize;
             }
         }
@@ -282,7 +282,7 @@ impl<TBitsStoreType: BitsStoreType, TStorage: EncodedStorage>
 
 #[cfg(target_arch = "x86_64")]
 extern "C" {
-    fn impl_xor_popcnt_sse_uint64(query_ptr: *const u64, vector_ptr: *const u64, count: u32)
+    fn impl_xor_popcnt_sse_uint128(query_ptr: *const u64, vector_ptr: *const u64, count: u32)
         -> u32;
 
     fn impl_xor_popcnt_sse_uint8(query_ptr: *const u8, vector_ptr: *const u8, count: u32) -> u32;

--- a/quantization/src/encoded_vectors_binary.rs
+++ b/quantization/src/encoded_vectors_binary.rs
@@ -5,19 +5,17 @@ use crate::{
     VectorParameters,
 };
 use serde::{Deserialize, Serialize};
+use std::marker::PhantomData;
 use std::path::Path;
 
-type BitsStoreType = u128;
-
-const BITS_STORE_TYPE_SIZE: usize = std::mem::size_of::<BitsStoreType>() * 8;
-
-pub struct EncodedVectorsBin<TStorage: EncodedStorage> {
+pub struct EncodedVectorsBin<TBitsStoreType: BitsStoreType, TStorage: EncodedStorage> {
     encoded_vectors: TStorage,
     metadata: Metadata,
+    bits_store_type: PhantomData<TBitsStoreType>,
 }
 
-pub struct EncodedBinVector {
-    encoded_vector: Vec<BitsStoreType>,
+pub struct EncodedBinVector<TBitsStoreType: BitsStoreType> {
+    encoded_vector: Vec<TBitsStoreType>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -25,7 +23,117 @@ struct Metadata {
     vector_parameters: VectorParameters,
 }
 
-impl<TStorage: EncodedStorage> EncodedVectorsBin<TStorage> {
+pub trait BitsStoreType:
+    Default + Copy + Clone + core::ops::BitOrAssign + std::ops::Shl<usize, Output = Self>
+{
+    fn bits_count() -> usize;
+
+    fn one() -> Self;
+
+    fn count_ones(self) -> usize;
+
+    /// Xor vectors and return the number of bits set to 1
+    ///
+    /// Assume that `v1` and `v2` are aligned to `BITS_STORE_TYPE_SIZE` with both with zeros
+    /// So it does not affect the resulting number of bits set to 1
+    fn xor_popcnt(v1: &[Self], v2: &[Self]) -> usize;
+}
+
+impl BitsStoreType for u8 {
+    fn bits_count() -> usize {
+        8
+    }
+
+    fn one() -> Self {
+        1
+    }
+
+    fn count_ones(self) -> usize {
+        self.count_ones() as usize
+    }
+
+    fn xor_popcnt(v1: &[Self], v2: &[Self]) -> usize {
+        debug_assert!(v1.len() == v2.len());
+
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        if is_x86_feature_detected!("sse4.2") {
+            unsafe {
+                return impl_xor_popcnt_sse_uint8(
+                    v1.as_ptr(),
+                    v2.as_ptr(),
+                    v1.len() as u32,
+                ) as usize;
+            }
+        }
+
+        #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+        if std::arch::is_aarch64_feature_detected!("neon") {
+            unsafe {
+                return impl_xor_popcnt_neon_uint8(
+                    v1.as_ptr(),
+                    v2.as_ptr(),
+                    v1.len() as u32,
+                ) as usize;
+            }
+        }
+
+        let mut result = 0;
+        for (&b1, &b2) in v1.iter().zip(v2.iter()) {
+            result += (b1 ^ b2).count_ones() as usize;
+        }
+        result
+    }
+}
+
+impl BitsStoreType for u128 {
+    fn bits_count() -> usize {
+        128
+    }
+
+    fn one() -> Self {
+        1
+    }
+
+    fn count_ones(self) -> usize {
+        self.count_ones() as usize
+    }
+
+    fn xor_popcnt(v1: &[Self], v2: &[Self]) -> usize {
+        debug_assert!(v1.len() == v2.len());
+
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        if is_x86_feature_detected!("sse4.2") {
+            unsafe {
+                return impl_xor_popcnt_sse_uint64(
+                    v1.as_ptr() as *const u64,
+                    v2.as_ptr() as *const u64,
+                    2 * v1.len() as u32, // multiply by 2 because we have u128 contains 2 u64 elements
+                ) as usize;
+            }
+        }
+
+        #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+        if std::arch::is_aarch64_feature_detected!("neon") {
+            unsafe {
+                return impl_xor_popcnt_neon_uint64(
+                    v1.as_ptr() as *const u64,
+                    v2.as_ptr() as *const u64,
+                    2 * v1.len() as u32, // multiply by 2 because we have u128 contains 2 u64 elements
+                ) as usize;
+            }
+        }
+
+        let mut result = 0;
+        for (&b1, &b2) in v1.iter().zip(v2.iter()) {
+            result += (b1 ^ b2).count_ones() as usize;
+        }
+        result
+    }
+}
+
+impl<TBitsStoreType: BitsStoreType, TStorage: EncodedStorage>
+    EncodedVectorsBin<TBitsStoreType, TStorage>
+{
     pub fn encode<'a>(
         orig_data: impl Iterator<Item = impl AsRef<[f32]> + 'a> + Clone,
         mut storage_builder: impl EncodedStorageBuilder<TStorage>,
@@ -39,7 +147,7 @@ impl<TStorage: EncodedStorage> EncodedVectorsBin<TStorage> {
                 return Err(EncodingError::Stopped);
             }
 
-            let encoded_vector = Self::_encode_vector(vector.as_ref());
+            let encoded_vector = Self::encode_vector(vector.as_ref());
             let encoded_vector_slice = encoded_vector.encoded_vector.as_slice();
             let bytes = transmute_to_u8_slice(encoded_vector_slice);
             storage_builder.push_vector_data(bytes);
@@ -50,77 +158,45 @@ impl<TStorage: EncodedStorage> EncodedVectorsBin<TStorage> {
             metadata: Metadata {
                 vector_parameters: vector_parameters.clone(),
             },
+            bits_store_type: PhantomData,
         })
     }
 
-    fn _encode_vector(vector: &[f32]) -> EncodedBinVector {
-        let mut encoded_vector = vec![0; Self::get_storage_size(vector.len())];
+    fn encode_vector(vector: &[f32]) -> EncodedBinVector<TBitsStoreType> {
+        let mut encoded_vector = vec![Default::default(); Self::get_storage_size(vector.len())];
 
+        let bits_count = TBitsStoreType::bits_count();
+        let one = TBitsStoreType::one();
         for (i, &v) in vector.iter().enumerate() {
             // flag is true if the value is positive
             // It's expected that the vector value is in range [-1; 1]
             if v > 0.0 {
-                encoded_vector[i / BITS_STORE_TYPE_SIZE] |= 1 << (i % BITS_STORE_TYPE_SIZE);
+                encoded_vector[i / bits_count] |= one << (i % bits_count);
             }
         }
 
         EncodedBinVector { encoded_vector }
     }
 
-    /// Xor vectors and return the number of bits set to 1
-    ///
-    /// Assume that `v1` and `v2` are aligned to `BITS_STORE_TYPE_SIZE` with both with zeros
-    /// So it does not affect the resulting number of bits set to 1
-    fn xor_product(v1: &[BitsStoreType], v2: &[BitsStoreType]) -> usize {
-        debug_assert!(v1.len() == v2.len());
-
-        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-        if is_x86_feature_detected!("sse4.1") {
-            unsafe {
-                return impl_xor_popcnt_sse(
-                    v1.as_ptr() as *const u64,
-                    v2.as_ptr() as *const u64,
-                    v1.len() as u32,
-                ) as usize;
-            }
-        }
-
-        #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
-        if std::arch::is_aarch64_feature_detected!("neon") {
-            unsafe {
-                return impl_xor_popcnt_neon(
-                    v1.as_ptr() as *const u64,
-                    v2.as_ptr() as *const u64,
-                    v1.len() as u32,
-                ) as usize;
-            }
-        }
-
-        let mut result = 0;
-        for (b1, b2) in v1.iter().zip(v2.iter()) {
-            result += (b1 ^ b2).count_ones() as usize;
-        }
-        result
-    }
-
     /// Estimates how many `StorageType` elements are needed to store `size` bits
     fn get_storage_size(size: usize) -> usize {
-        let mut result = size / BITS_STORE_TYPE_SIZE;
-        if size % BITS_STORE_TYPE_SIZE != 0 {
+        let bits_count = TBitsStoreType::bits_count();
+        let mut result = size / bits_count;
+        if size % bits_count != 0 {
             result += 1;
         }
         result
     }
 
     pub fn get_quantized_vector_size_from_params(vector_parameters: &VectorParameters) -> usize {
-        Self::get_storage_size(vector_parameters.dim) * std::mem::size_of::<BitsStoreType>()
+        Self::get_storage_size(vector_parameters.dim) * std::mem::size_of::<TBitsStoreType>()
     }
 
     fn get_quantized_vector_size(&self) -> usize {
         Self::get_quantized_vector_size_from_params(&self.metadata.vector_parameters)
     }
 
-    fn calculate_metric(&self, v1: &[BitsStoreType], v2: &[BitsStoreType]) -> f32 {
+    fn calculate_metric(&self, v1: &[TBitsStoreType], v2: &[TBitsStoreType]) -> f32 {
         // Dot product in a range [-1; 1] is approximated by NXOR in a range [0; 1]
         // L1 distance in range [-1; 1] (alpha=2) is approximated by alpha*XOR in a range [0; 1]
         // L2 distance in range [-1; 1] (alpha=2) is approximated by alpha*sqrt(XOR) in a range [0; 1]
@@ -138,7 +214,7 @@ impl<TStorage: EncodedStorage> EncodedVectorsBin<TStorage> {
         // | 1 | 0 | 0    | 1
         // | 1 | 1 | 1    | 0
 
-        let xor_product = Self::xor_product(v1, v2) as f32;
+        let xor_product = TBitsStoreType::xor_popcnt(v1, v2) as f32;
 
         let dim = self.metadata.vector_parameters.dim as f32;
         let zeros_count = dim - xor_product;
@@ -157,7 +233,10 @@ impl<TStorage: EncodedStorage> EncodedVectorsBin<TStorage> {
     }
 }
 
-impl<TStorage: EncodedStorage> EncodedVectors<EncodedBinVector> for EncodedVectorsBin<TStorage> {
+impl<TBitsStoreType: BitsStoreType, TStorage: EncodedStorage>
+    EncodedVectors<EncodedBinVector<TBitsStoreType>>
+    for EncodedVectorsBin<TBitsStoreType, TStorage>
+{
     fn save(&self, data_path: &Path, meta_path: &Path) -> std::io::Result<()> {
         let metadata_bytes = serde_json::to_vec(&self.metadata)?;
         meta_path.parent().map(std::fs::create_dir_all);
@@ -181,16 +260,17 @@ impl<TStorage: EncodedStorage> EncodedVectors<EncodedBinVector> for EncodedVecto
         let result = Self {
             metadata,
             encoded_vectors,
+            bits_store_type: PhantomData,
         };
         Ok(result)
     }
 
-    fn encode_query(&self, query: &[f32]) -> EncodedBinVector {
+    fn encode_query(&self, query: &[f32]) -> EncodedBinVector<TBitsStoreType> {
         debug_assert!(query.len() == self.metadata.vector_parameters.dim);
-        Self::_encode_vector(query)
+        Self::encode_vector(query)
     }
 
-    fn score_point(&self, query: &EncodedBinVector, i: u32) -> f32 {
+    fn score_point(&self, query: &EncodedBinVector<TBitsStoreType>, i: u32) -> f32 {
         let vector_data_1 = self
             .encoded_vectors
             .get_vector_data(i as _, self.get_quantized_vector_size());
@@ -216,10 +296,17 @@ impl<TStorage: EncodedStorage> EncodedVectors<EncodedBinVector> for EncodedVecto
 
 #[cfg(target_arch = "x86_64")]
 extern "C" {
-    fn impl_xor_popcnt_sse(query_ptr: *const u64, vector_ptr: *const u64, count: u32) -> u32;
+    fn impl_xor_popcnt_sse_uint64(query_ptr: *const u64, vector_ptr: *const u64, count: u32)
+        -> u32;
+    fn impl_xor_popcnt_sse_uint8(query_ptr: *const u8, vector_ptr: *const u8, count: u32) -> u32;
 }
 
 #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 extern "C" {
-    fn impl_xor_popcnt_neon(query_ptr: *const u64, vector_ptr: *const u64, count: u32) -> u32;
+    fn impl_xor_popcnt_neon_uint64(
+        query_ptr: *const u64,
+        vector_ptr: *const u64,
+        count: u32,
+    ) -> u32;
+    fn impl_xor_popcnt_neon_uint8(query_ptr: *const u8, vector_ptr: *const u8, count: u32) -> u32;
 }

--- a/quantization/src/encoded_vectors_binary.rs
+++ b/quantization/src/encoded_vectors_binary.rs
@@ -58,22 +58,8 @@ impl BitsStoreType for u8 {
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         if is_x86_feature_detected!("sse4.2") {
             unsafe {
-                return impl_xor_popcnt_sse_uint8(
-                    v1.as_ptr(),
-                    v2.as_ptr(),
-                    v1.len() as u32,
-                ) as usize;
-            }
-        }
-
-        #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
-        if std::arch::is_aarch64_feature_detected!("neon") {
-            unsafe {
-                return impl_xor_popcnt_neon_uint8(
-                    v1.as_ptr(),
-                    v2.as_ptr(),
-                    v1.len() as u32,
-                ) as usize;
+                return impl_xor_popcnt_sse_uint8(v1.as_ptr(), v2.as_ptr(), v1.len() as u32)
+                    as usize;
             }
         }
 
@@ -107,7 +93,7 @@ impl BitsStoreType for u128 {
                 return impl_xor_popcnt_sse_uint64(
                     v1.as_ptr() as *const u64,
                     v2.as_ptr() as *const u64,
-                    2 * v1.len() as u32, // multiply by 2 because we have u128 contains 2 u64 elements
+                    2 * v1.len() as u32, // multiply by 2 because u128 contains 2 u64 elements
                 ) as usize;
             }
         }
@@ -115,10 +101,10 @@ impl BitsStoreType for u128 {
         #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
         if std::arch::is_aarch64_feature_detected!("neon") {
             unsafe {
-                return impl_xor_popcnt_neon_uint64(
-                    v1.as_ptr() as *const u64,
-                    v2.as_ptr() as *const u64,
-                    2 * v1.len() as u32, // multiply by 2 because we have u128 contains 2 u64 elements
+                return impl_xor_popcnt_neon_uint128(
+                    v1.as_ptr() as *const u8,
+                    v2.as_ptr() as *const u8,
+                    v1.len() as u32,
                 ) as usize;
             }
         }
@@ -298,15 +284,12 @@ impl<TBitsStoreType: BitsStoreType, TStorage: EncodedStorage>
 extern "C" {
     fn impl_xor_popcnt_sse_uint64(query_ptr: *const u64, vector_ptr: *const u64, count: u32)
         -> u32;
+
     fn impl_xor_popcnt_sse_uint8(query_ptr: *const u8, vector_ptr: *const u8, count: u32) -> u32;
 }
 
 #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 extern "C" {
-    fn impl_xor_popcnt_neon_uint64(
-        query_ptr: *const u64,
-        vector_ptr: *const u64,
-        count: u32,
-    ) -> u32;
-    fn impl_xor_popcnt_neon_uint8(query_ptr: *const u8, vector_ptr: *const u8, count: u32) -> u32;
+    fn impl_xor_popcnt_neon_uint128(query_ptr: *const u8, vector_ptr: *const u8, count: u32)
+        -> u32;
 }

--- a/quantization/src/encoded_vectors_binary.rs
+++ b/quantization/src/encoded_vectors_binary.rs
@@ -26,11 +26,7 @@ struct Metadata {
 pub trait BitsStoreType:
     Default + Copy + Clone + core::ops::BitOrAssign + std::ops::Shl<usize, Output = Self>
 {
-    fn bits_count() -> usize;
-
     fn one() -> Self;
-
-    fn count_ones(self) -> usize;
 
     /// Xor vectors and return the number of bits set to 1
     ///
@@ -40,16 +36,8 @@ pub trait BitsStoreType:
 }
 
 impl BitsStoreType for u8 {
-    fn bits_count() -> usize {
-        8
-    }
-
     fn one() -> Self {
         1
-    }
-
-    fn count_ones(self) -> usize {
-        self.count_ones() as usize
     }
 
     fn xor_popcnt(v1: &[Self], v2: &[Self]) -> usize {
@@ -72,16 +60,8 @@ impl BitsStoreType for u8 {
 }
 
 impl BitsStoreType for u128 {
-    fn bits_count() -> usize {
-        128
-    }
-
     fn one() -> Self {
         1
-    }
-
-    fn count_ones(self) -> usize {
-        self.count_ones() as usize
     }
 
     fn xor_popcnt(v1: &[Self], v2: &[Self]) -> usize {
@@ -151,7 +131,7 @@ impl<TBitsStoreType: BitsStoreType, TStorage: EncodedStorage>
     fn encode_vector(vector: &[f32]) -> EncodedBinVector<TBitsStoreType> {
         let mut encoded_vector = vec![Default::default(); Self::get_storage_size(vector.len())];
 
-        let bits_count = TBitsStoreType::bits_count();
+        let bits_count = 8 * std::mem::size_of::<TBitsStoreType>();
         let one = TBitsStoreType::one();
         for (i, &v) in vector.iter().enumerate() {
             // flag is true if the value is positive
@@ -166,7 +146,7 @@ impl<TBitsStoreType: BitsStoreType, TStorage: EncodedStorage>
 
     /// Estimates how many `StorageType` elements are needed to store `size` bits
     fn get_storage_size(size: usize) -> usize {
-        let bits_count = TBitsStoreType::bits_count();
+        let bits_count = 8 * std::mem::size_of::<TBitsStoreType>();
         let mut result = size / bits_count;
         if size % bits_count != 0 {
             result += 1;

--- a/quantization/src/encoded_vectors_binary.rs
+++ b/quantization/src/encoded_vectors_binary.rs
@@ -24,10 +24,8 @@ struct Metadata {
 }
 
 pub trait BitsStoreType:
-    Default + Copy + Clone + core::ops::BitOrAssign + std::ops::Shl<usize, Output = Self>
+    Default + Copy + Clone + core::ops::BitOrAssign + std::ops::Shl<usize, Output = Self> + num_traits::identities::One
 {
-    fn one() -> Self;
-
     /// Xor vectors and return the number of bits set to 1
     ///
     /// Assume that `v1` and `v2` are aligned to `BITS_STORE_TYPE_SIZE` with both with zeros
@@ -36,10 +34,6 @@ pub trait BitsStoreType:
 }
 
 impl BitsStoreType for u8 {
-    fn one() -> Self {
-        1
-    }
-
     fn xor_popcnt(v1: &[Self], v2: &[Self]) -> usize {
         debug_assert!(v1.len() == v2.len());
 
@@ -60,10 +54,6 @@ impl BitsStoreType for u8 {
 }
 
 impl BitsStoreType for u128 {
-    fn one() -> Self {
-        1
-    }
-
     fn xor_popcnt(v1: &[Self], v2: &[Self]) -> usize {
         debug_assert!(v1.len() == v2.len());
 
@@ -268,11 +258,30 @@ extern "C" {
         count: u32,
     ) -> u32;
 
-    fn impl_xor_popcnt_sse_uint8(query_ptr: *const u8, vector_ptr: *const u8, count: u32) -> u32;
+    fn impl_xor_popcnt_sse_uint64(
+        query_ptr: *const u64,
+        vector_ptr: *const u64,
+        count: u32,
+    ) -> u32;
+
+    fn impl_xor_popcnt_sse_uint32(
+        query_ptr: *const u64,
+        vector_ptr: *const u64,
+        count: u32,
+    ) -> u32;
 }
 
 #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 extern "C" {
-    fn impl_xor_popcnt_neon_uint128(query_ptr: *const u8, vector_ptr: *const u8, count: u32)
-        -> u32;
+    fn impl_xor_popcnt_neon_uint128(
+        query_ptr: *const u8,
+        vector_ptr: *const u8,
+        count: u32,
+    ) -> u32;
+
+    fn impl_xor_popcnt_neon_uint64(
+        query_ptr: *const u8,
+        vector_ptr: *const u8,
+        count: u32,
+    ) -> u32;
 }

--- a/quantization/src/encoded_vectors_binary.rs
+++ b/quantization/src/encoded_vectors_binary.rs
@@ -282,8 +282,11 @@ impl<TBitsStoreType: BitsStoreType, TStorage: EncodedStorage>
 
 #[cfg(target_arch = "x86_64")]
 extern "C" {
-    fn impl_xor_popcnt_sse_uint128(query_ptr: *const u64, vector_ptr: *const u64, count: u32)
-        -> u32;
+    fn impl_xor_popcnt_sse_uint128(
+        query_ptr: *const u64,
+        vector_ptr: *const u64,
+        count: u32,
+    ) -> u32;
 
     fn impl_xor_popcnt_sse_uint8(query_ptr: *const u8, vector_ptr: *const u8, count: u32) -> u32;
 }

--- a/quantization/src/encoded_vectors_binary.rs
+++ b/quantization/src/encoded_vectors_binary.rs
@@ -107,7 +107,7 @@ impl BitsStoreType for u8 {
             std::mem::size_of::<u8>()
         };
 
-        let bits_count = 8 * bytes_count;
+        let bits_count = u8::BITS as usize * bytes_count;
         let mut result = size / bits_count;
         if size % bits_count != 0 {
             result += 1;
@@ -194,7 +194,7 @@ impl<TBitsStoreType: BitsStoreType, TStorage: EncodedStorage>
         let mut encoded_vector =
             vec![Default::default(); TBitsStoreType::get_storage_size(vector.len())];
 
-        let bits_count = 8 * std::mem::size_of::<TBitsStoreType>();
+        let bits_count = u8::BITS as usize * std::mem::size_of::<TBitsStoreType>();
         let one = TBitsStoreType::one();
         for (i, &v) in vector.iter().enumerate() {
             // flag is true if the value is positive

--- a/quantization/tests/test_binary.rs
+++ b/quantization/tests/test_binary.rs
@@ -5,7 +5,7 @@ mod metrics;
 mod tests {
     use quantization::{
         encoded_vectors::{DistanceType, EncodedVectors, VectorParameters},
-        encoded_vectors_binary::EncodedVectorsBin,
+        encoded_vectors_binary::{BitsStoreType, EncodedVectorsBin},
     };
     use rand::{Rng, SeedableRng};
 
@@ -26,8 +26,13 @@ mod tests {
 
     #[test]
     fn test_binary_dot() {
+        test_binary_dot_impl::<u8>();
+        test_binary_dot_impl::<u128>();
+    }
+
+    fn test_binary_dot_impl<TBitsStoreType: BitsStoreType>() {
         let vectors_count = 128;
-        let vector_dim = 3 * 128;
+        let vector_dim = 3 * 129;
         let error = vector_dim as f32 * 0.01;
 
         //let mut rng = rand::thread_rng();
@@ -37,7 +42,7 @@ mod tests {
             vector_data.push(generate_vector(vector_dim, &mut rng));
         }
 
-        let encoded = EncodedVectorsBin::encode(
+        let encoded = EncodedVectorsBin::<TBitsStoreType, _>::encode(
             vector_data.iter(),
             Vec::<u8>::new(),
             &VectorParameters {
@@ -62,8 +67,13 @@ mod tests {
 
     #[test]
     fn test_binary_dot_inverted() {
+        test_binary_dot_inverted_impl::<u8>();
+        test_binary_dot_inverted_impl::<u128>();
+    }
+
+    fn test_binary_dot_inverted_impl<TBitsStoreType: BitsStoreType>() {
         let vectors_count = 128;
-        let vector_dim = 128;
+        let vector_dim = 3 * 129;
         let error = vector_dim as f32 * 0.01;
 
         //let mut rng = rand::thread_rng();
@@ -73,7 +83,7 @@ mod tests {
             vector_data.push(generate_vector(vector_dim, &mut rng));
         }
 
-        let encoded = EncodedVectorsBin::encode(
+        let encoded = EncodedVectorsBin::<TBitsStoreType, _>::encode(
             vector_data.iter(),
             Vec::<u8>::new(),
             &VectorParameters {
@@ -98,8 +108,13 @@ mod tests {
 
     #[test]
     fn test_binary_dot_internal() {
+        test_binary_dot_internal_impl::<u8>();
+        test_binary_dot_internal_impl::<u128>();
+    }
+
+    fn test_binary_dot_internal_impl<TBitsStoreType: BitsStoreType>() {
         let vectors_count = 128;
-        let vector_dim = 128;
+        let vector_dim = 3 * 129;
         let error = vector_dim as f32 * 0.01;
 
         //let mut rng = rand::thread_rng();
@@ -109,7 +124,7 @@ mod tests {
             vector_data.push(generate_vector(vector_dim, &mut rng));
         }
 
-        let encoded = EncodedVectorsBin::encode(
+        let encoded = EncodedVectorsBin::<TBitsStoreType, _>::encode(
             vector_data.iter(),
             Vec::<u8>::new(),
             &VectorParameters {
@@ -131,8 +146,13 @@ mod tests {
 
     #[test]
     fn test_binary_dot_inverted_internal() {
+        test_binary_dot_inverted_internal_impl::<u8>();
+        test_binary_dot_inverted_internal_impl::<u128>();
+    }
+
+    fn test_binary_dot_inverted_internal_impl<TBitsStoreType: BitsStoreType>() {
         let vectors_count = 128;
-        let vector_dim = 128;
+        let vector_dim = 3 * 129;
         let error = vector_dim as f32 * 0.01;
 
         //let mut rng = rand::thread_rng();
@@ -142,7 +162,7 @@ mod tests {
             vector_data.push(generate_vector(vector_dim, &mut rng));
         }
 
-        let encoded = EncodedVectorsBin::encode(
+        let encoded = EncodedVectorsBin::<TBitsStoreType, _>::encode(
             vector_data.iter(),
             Vec::<u8>::new(),
             &VectorParameters {
@@ -164,8 +184,13 @@ mod tests {
 
     #[test]
     fn test_binary_l1() {
+        test_binary_l1_impl::<u8>();
+        test_binary_l1_impl::<u128>();
+    }
+
+    fn test_binary_l1_impl<TBitsStoreType: BitsStoreType>() {
         let vectors_count = 128;
-        let vector_dim = 3 * 128;
+        let vector_dim = 3 * 129;
 
         //let mut rng = rand::thread_rng();
         let mut rng = rand::rngs::StdRng::seed_from_u64(42);
@@ -174,7 +199,7 @@ mod tests {
             vector_data.push(generate_vector(vector_dim, &mut rng));
         }
 
-        let encoded = EncodedVectorsBin::encode(
+        let encoded = EncodedVectorsBin::<TBitsStoreType, _>::encode(
             vector_data.iter(),
             Vec::<u8>::new(),
             &VectorParameters {
@@ -215,8 +240,13 @@ mod tests {
 
     #[test]
     fn test_binary_l1_inverted() {
+        test_binary_l1_inverted_impl::<u8>();
+        test_binary_l1_inverted_impl::<u128>();
+    }
+
+    fn test_binary_l1_inverted_impl<TBitsStoreType: BitsStoreType>() {
         let vectors_count = 128;
-        let vector_dim = 128;
+        let vector_dim = 3 * 129;
 
         //let mut rng = rand::thread_rng();
         let mut rng = rand::rngs::StdRng::seed_from_u64(42);
@@ -225,7 +255,7 @@ mod tests {
             vector_data.push(generate_vector(vector_dim, &mut rng));
         }
 
-        let encoded = EncodedVectorsBin::encode(
+        let encoded = EncodedVectorsBin::<TBitsStoreType, _>::encode(
             vector_data.iter(),
             Vec::<u8>::new(),
             &VectorParameters {
@@ -266,8 +296,13 @@ mod tests {
 
     #[test]
     fn test_binary_l1_internal() {
+        test_binary_l1_internal_impl::<u8>();
+        test_binary_l1_internal_impl::<u128>();
+    }
+
+    fn test_binary_l1_internal_impl<TBitsStoreType: BitsStoreType>() {
         let vectors_count = 128;
-        let vector_dim = 128;
+        let vector_dim = 3 * 129;
 
         //let mut rng = rand::thread_rng();
         let mut rng = rand::rngs::StdRng::seed_from_u64(42);
@@ -276,7 +311,7 @@ mod tests {
             vector_data.push(generate_vector(vector_dim, &mut rng));
         }
 
-        let encoded = EncodedVectorsBin::encode(
+        let encoded = EncodedVectorsBin::<TBitsStoreType, _>::encode(
             vector_data.iter(),
             Vec::<u8>::new(),
             &VectorParameters {
@@ -314,8 +349,13 @@ mod tests {
 
     #[test]
     fn test_binary_l1_inverted_internal() {
+        test_binary_l1_inverted_internal_impl::<u8>();
+        test_binary_l1_inverted_internal_impl::<u128>();
+    }
+
+    fn test_binary_l1_inverted_internal_impl<TBitsStoreType: BitsStoreType>() {
         let vectors_count = 128;
-        let vector_dim = 128;
+        let vector_dim = 3 * 129;
 
         //let mut rng = rand::thread_rng();
         let mut rng = rand::rngs::StdRng::seed_from_u64(42);
@@ -324,7 +364,7 @@ mod tests {
             vector_data.push(generate_vector(vector_dim, &mut rng));
         }
 
-        let encoded = EncodedVectorsBin::encode(
+        let encoded = EncodedVectorsBin::<TBitsStoreType, _>::encode(
             vector_data.iter(),
             Vec::<u8>::new(),
             &VectorParameters {
@@ -362,8 +402,13 @@ mod tests {
 
     #[test]
     fn test_binary_l2() {
+        test_binary_l2_impl::<u8>();
+        test_binary_l2_impl::<u128>();
+    }
+
+    fn test_binary_l2_impl<TBitsStoreType: BitsStoreType>() {
         let vectors_count = 128;
-        let vector_dim = 3 * 128;
+        let vector_dim = 3 * 129;
 
         //let mut rng = rand::thread_rng();
         let mut rng = rand::rngs::StdRng::seed_from_u64(42);
@@ -372,7 +417,7 @@ mod tests {
             vector_data.push(generate_vector(vector_dim, &mut rng));
         }
 
-        let encoded = EncodedVectorsBin::encode(
+        let encoded = EncodedVectorsBin::<TBitsStoreType, _>::encode(
             vector_data.iter(),
             Vec::<u8>::new(),
             &VectorParameters {
@@ -413,8 +458,13 @@ mod tests {
 
     #[test]
     fn test_binary_l2_inverted() {
+        test_binary_l2_inverted_impl::<u8>();
+        test_binary_l2_inverted_impl::<u128>();
+    }
+
+    fn test_binary_l2_inverted_impl<TBitsStoreType: BitsStoreType>() {
         let vectors_count = 128;
-        let vector_dim = 128;
+        let vector_dim = 3 * 129;
 
         //let mut rng = rand::thread_rng();
         let mut rng = rand::rngs::StdRng::seed_from_u64(42);
@@ -423,7 +473,7 @@ mod tests {
             vector_data.push(generate_vector(vector_dim, &mut rng));
         }
 
-        let encoded = EncodedVectorsBin::encode(
+        let encoded = EncodedVectorsBin::<TBitsStoreType, _>::encode(
             vector_data.iter(),
             Vec::<u8>::new(),
             &VectorParameters {
@@ -464,8 +514,13 @@ mod tests {
 
     #[test]
     fn test_binary_l2_internal() {
+        test_binary_l2_internal_impl::<u8>();
+        test_binary_l2_internal_impl::<u128>();
+    }
+
+    fn test_binary_l2_internal_impl<TBitsStoreType: BitsStoreType>() {
         let vectors_count = 128;
-        let vector_dim = 128;
+        let vector_dim = 3 * 129;
 
         //let mut rng = rand::thread_rng();
         let mut rng = rand::rngs::StdRng::seed_from_u64(42);
@@ -474,7 +529,7 @@ mod tests {
             vector_data.push(generate_vector(vector_dim, &mut rng));
         }
 
-        let encoded = EncodedVectorsBin::encode(
+        let encoded = EncodedVectorsBin::<TBitsStoreType, _>::encode(
             vector_data.iter(),
             Vec::<u8>::new(),
             &VectorParameters {
@@ -512,8 +567,13 @@ mod tests {
 
     #[test]
     fn test_binary_l2_inverted_internal() {
+        test_binary_l2_inverted_internal_impl::<u8>();
+        test_binary_l2_inverted_internal_impl::<u128>();
+    }
+
+    fn test_binary_l2_inverted_internal_impl<TBitsStoreType: BitsStoreType>() {
         let vectors_count = 128;
-        let vector_dim = 128;
+        let vector_dim = 3 * 129;
 
         //let mut rng = rand::thread_rng();
         let mut rng = rand::rngs::StdRng::seed_from_u64(42);
@@ -522,7 +582,7 @@ mod tests {
             vector_data.push(generate_vector(vector_dim, &mut rng));
         }
 
-        let encoded = EncodedVectorsBin::encode(
+        let encoded = EncodedVectorsBin::<TBitsStoreType, _>::encode(
             vector_data.iter(),
             Vec::<u8>::new(),
             &VectorParameters {

--- a/quantization/tests/test_binary.rs
+++ b/quantization/tests/test_binary.rs
@@ -32,6 +32,7 @@ mod tests {
         test_binary_dot_impl::<u8>(33);
         test_binary_dot_impl::<u8>(65);
         test_binary_dot_impl::<u8>(3 * 129);
+        test_binary_dot_impl::<u128>(1);
         test_binary_dot_impl::<u128>(3 * 129);
     }
 
@@ -77,6 +78,7 @@ mod tests {
         test_binary_dot_inverted_impl::<u8>(33);
         test_binary_dot_inverted_impl::<u8>(65);
         test_binary_dot_inverted_impl::<u8>(3 * 129);
+        test_binary_dot_inverted_impl::<u128>(1);
         test_binary_dot_inverted_impl::<u128>(3 * 129);
     }
 
@@ -122,6 +124,7 @@ mod tests {
         test_binary_dot_internal_impl::<u8>(33);
         test_binary_dot_internal_impl::<u8>(65);
         test_binary_dot_internal_impl::<u8>(3 * 129);
+        test_binary_dot_internal_impl::<u128>(1);
         test_binary_dot_internal_impl::<u128>(3 * 129);
     }
 
@@ -164,6 +167,7 @@ mod tests {
         test_binary_dot_inverted_internal_impl::<u8>(33);
         test_binary_dot_inverted_internal_impl::<u8>(65);
         test_binary_dot_inverted_internal_impl::<u8>(3 * 129);
+        test_binary_dot_inverted_internal_impl::<u128>(1);
         test_binary_dot_inverted_internal_impl::<u128>(3 * 129);
     }
 
@@ -206,6 +210,7 @@ mod tests {
         test_binary_l1_impl::<u8>(33);
         test_binary_l1_impl::<u8>(65);
         test_binary_l1_impl::<u8>(3 * 129);
+        test_binary_l1_impl::<u128>(1);
         test_binary_l1_impl::<u128>(3 * 129);
     }
 
@@ -266,6 +271,7 @@ mod tests {
         test_binary_l1_inverted_impl::<u8>(33);
         test_binary_l1_inverted_impl::<u8>(65);
         test_binary_l1_inverted_impl::<u8>(3 * 129);
+        test_binary_l1_inverted_impl::<u128>(1);
         test_binary_l1_inverted_impl::<u128>(3 * 129);
     }
 
@@ -326,6 +332,7 @@ mod tests {
         test_binary_l1_internal_impl::<u8>(33);
         test_binary_l1_internal_impl::<u8>(65);
         test_binary_l1_internal_impl::<u8>(3 * 129);
+        test_binary_l1_internal_impl::<u128>(1);
         test_binary_l1_internal_impl::<u128>(3 * 129);
     }
 
@@ -383,6 +390,7 @@ mod tests {
         test_binary_l1_inverted_internal_impl::<u8>(33);
         test_binary_l1_inverted_internal_impl::<u8>(65);
         test_binary_l1_inverted_internal_impl::<u8>(3 * 129);
+        test_binary_l1_inverted_internal_impl::<u128>(1);
         test_binary_l1_inverted_internal_impl::<u128>(3 * 129);
     }
 
@@ -440,6 +448,7 @@ mod tests {
         test_binary_l2_impl::<u8>(33);
         test_binary_l2_impl::<u8>(65);
         test_binary_l2_impl::<u8>(3 * 129);
+        test_binary_l2_impl::<u128>(1);
         test_binary_l2_impl::<u128>(3 * 129);
     }
 
@@ -500,6 +509,7 @@ mod tests {
         test_binary_l2_inverted_impl::<u8>(33);
         test_binary_l2_inverted_impl::<u8>(65);
         test_binary_l2_inverted_impl::<u8>(3 * 129);
+        test_binary_l2_inverted_impl::<u128>(1);
         test_binary_l2_inverted_impl::<u128>(3 * 129);
     }
 
@@ -560,6 +570,7 @@ mod tests {
         test_binary_l2_internal_impl::<u8>(33);
         test_binary_l2_internal_impl::<u8>(65);
         test_binary_l2_internal_impl::<u8>(3 * 129);
+        test_binary_l2_internal_impl::<u128>(1);
         test_binary_l2_internal_impl::<u128>(3 * 129);
     }
 
@@ -617,6 +628,7 @@ mod tests {
         test_binary_l2_inverted_internal_impl::<u8>(33);
         test_binary_l2_inverted_internal_impl::<u8>(65);
         test_binary_l2_inverted_internal_impl::<u8>(3 * 129);
+        test_binary_l2_inverted_internal_impl::<u128>(1);
         test_binary_l2_inverted_internal_impl::<u128>(3 * 129);
     }
 

--- a/quantization/tests/test_binary.rs
+++ b/quantization/tests/test_binary.rs
@@ -26,13 +26,17 @@ mod tests {
 
     #[test]
     fn test_binary_dot() {
-        test_binary_dot_impl::<u8>();
-        test_binary_dot_impl::<u128>();
+        test_binary_dot_impl::<u8>(0);
+        test_binary_dot_impl::<u8>(1);
+        test_binary_dot_impl::<u8>(8);
+        test_binary_dot_impl::<u8>(33);
+        test_binary_dot_impl::<u8>(65);
+        test_binary_dot_impl::<u8>(3 * 129);
+        test_binary_dot_impl::<u128>(3 * 129);
     }
 
-    fn test_binary_dot_impl<TBitsStoreType: BitsStoreType>() {
+    fn test_binary_dot_impl<TBitsStoreType: BitsStoreType>(vector_dim: usize) {
         let vectors_count = 128;
-        let vector_dim = 3 * 129;
         let error = vector_dim as f32 * 0.01;
 
         //let mut rng = rand::thread_rng();
@@ -61,19 +65,23 @@ mod tests {
         for (index, vector) in vector_data.iter().enumerate() {
             let score = encoded.score_point(&query_u8, index as u32);
             let orginal_score = dot_similarity(&query, vector);
-            assert!((score - orginal_score).abs() < error);
+            assert!((score - orginal_score).abs() <= error);
         }
     }
 
     #[test]
     fn test_binary_dot_inverted() {
-        test_binary_dot_inverted_impl::<u8>();
-        test_binary_dot_inverted_impl::<u128>();
+        test_binary_dot_inverted_impl::<u8>(0);
+        test_binary_dot_inverted_impl::<u8>(1);
+        test_binary_dot_inverted_impl::<u8>(8);
+        test_binary_dot_inverted_impl::<u8>(33);
+        test_binary_dot_inverted_impl::<u8>(65);
+        test_binary_dot_inverted_impl::<u8>(3 * 129);
+        test_binary_dot_inverted_impl::<u128>(3 * 129);
     }
 
-    fn test_binary_dot_inverted_impl<TBitsStoreType: BitsStoreType>() {
+    fn test_binary_dot_inverted_impl<TBitsStoreType: BitsStoreType>(vector_dim: usize) {
         let vectors_count = 128;
-        let vector_dim = 3 * 129;
         let error = vector_dim as f32 * 0.01;
 
         //let mut rng = rand::thread_rng();
@@ -102,19 +110,23 @@ mod tests {
         for (index, vector) in vector_data.iter().enumerate() {
             let score = encoded.score_point(&query_u8, index as u32);
             let orginal_score = -dot_similarity(&query, vector);
-            assert!((score - orginal_score).abs() < error);
+            assert!((score - orginal_score).abs() <= error);
         }
     }
 
     #[test]
     fn test_binary_dot_internal() {
-        test_binary_dot_internal_impl::<u8>();
-        test_binary_dot_internal_impl::<u128>();
+        test_binary_dot_internal_impl::<u8>(0);
+        test_binary_dot_internal_impl::<u8>(1);
+        test_binary_dot_internal_impl::<u8>(8);
+        test_binary_dot_internal_impl::<u8>(33);
+        test_binary_dot_internal_impl::<u8>(65);
+        test_binary_dot_internal_impl::<u8>(3 * 129);
+        test_binary_dot_internal_impl::<u128>(3 * 129);
     }
 
-    fn test_binary_dot_internal_impl<TBitsStoreType: BitsStoreType>() {
+    fn test_binary_dot_internal_impl<TBitsStoreType: BitsStoreType>(vector_dim: usize) {
         let vectors_count = 128;
-        let vector_dim = 3 * 129;
         let error = vector_dim as f32 * 0.01;
 
         //let mut rng = rand::thread_rng();
@@ -140,19 +152,23 @@ mod tests {
         for i in 1..vectors_count {
             let score = encoded.score_internal(0, i as u32);
             let orginal_score = dot_similarity(&vector_data[0], &vector_data[i]);
-            assert!((score - orginal_score).abs() < error);
+            assert!((score - orginal_score).abs() <= error);
         }
     }
 
     #[test]
     fn test_binary_dot_inverted_internal() {
-        test_binary_dot_inverted_internal_impl::<u8>();
-        test_binary_dot_inverted_internal_impl::<u128>();
+        test_binary_dot_inverted_internal_impl::<u8>(0);
+        test_binary_dot_inverted_internal_impl::<u8>(1);
+        test_binary_dot_inverted_internal_impl::<u8>(8);
+        test_binary_dot_inverted_internal_impl::<u8>(33);
+        test_binary_dot_inverted_internal_impl::<u8>(65);
+        test_binary_dot_inverted_internal_impl::<u8>(3 * 129);
+        test_binary_dot_inverted_internal_impl::<u128>(3 * 129);
     }
 
-    fn test_binary_dot_inverted_internal_impl<TBitsStoreType: BitsStoreType>() {
+    fn test_binary_dot_inverted_internal_impl<TBitsStoreType: BitsStoreType>(vector_dim: usize) {
         let vectors_count = 128;
-        let vector_dim = 3 * 129;
         let error = vector_dim as f32 * 0.01;
 
         //let mut rng = rand::thread_rng();
@@ -178,19 +194,23 @@ mod tests {
         for i in 1..vectors_count {
             let score = encoded.score_internal(0, i as u32);
             let orginal_score = -dot_similarity(&vector_data[0], &vector_data[i]);
-            assert!((score - orginal_score).abs() < error);
+            assert!((score - orginal_score).abs() <= error);
         }
     }
 
     #[test]
     fn test_binary_l1() {
-        test_binary_l1_impl::<u8>();
-        test_binary_l1_impl::<u128>();
+        test_binary_l1_impl::<u8>(0);
+        test_binary_l1_impl::<u8>(1);
+        test_binary_l1_impl::<u8>(8);
+        test_binary_l1_impl::<u8>(33);
+        test_binary_l1_impl::<u8>(65);
+        test_binary_l1_impl::<u8>(3 * 129);
+        test_binary_l1_impl::<u128>(3 * 129);
     }
 
-    fn test_binary_l1_impl<TBitsStoreType: BitsStoreType>() {
+    fn test_binary_l1_impl<TBitsStoreType: BitsStoreType>(vector_dim: usize) {
         let vectors_count = 128;
-        let vector_dim = 3 * 129;
 
         //let mut rng = rand::thread_rng();
         let mut rng = rand::rngs::StdRng::seed_from_u64(42);
@@ -240,13 +260,17 @@ mod tests {
 
     #[test]
     fn test_binary_l1_inverted() {
-        test_binary_l1_inverted_impl::<u8>();
-        test_binary_l1_inverted_impl::<u128>();
+        test_binary_l1_inverted_impl::<u8>(0);
+        test_binary_l1_inverted_impl::<u8>(1);
+        test_binary_l1_inverted_impl::<u8>(8);
+        test_binary_l1_inverted_impl::<u8>(33);
+        test_binary_l1_inverted_impl::<u8>(65);
+        test_binary_l1_inverted_impl::<u8>(3 * 129);
+        test_binary_l1_inverted_impl::<u128>(3 * 129);
     }
 
-    fn test_binary_l1_inverted_impl<TBitsStoreType: BitsStoreType>() {
+    fn test_binary_l1_inverted_impl<TBitsStoreType: BitsStoreType>(vector_dim: usize) {
         let vectors_count = 128;
-        let vector_dim = 3 * 129;
 
         //let mut rng = rand::thread_rng();
         let mut rng = rand::rngs::StdRng::seed_from_u64(42);
@@ -296,13 +320,17 @@ mod tests {
 
     #[test]
     fn test_binary_l1_internal() {
-        test_binary_l1_internal_impl::<u8>();
-        test_binary_l1_internal_impl::<u128>();
+        test_binary_l1_internal_impl::<u8>(0);
+        test_binary_l1_internal_impl::<u8>(1);
+        test_binary_l1_internal_impl::<u8>(8);
+        test_binary_l1_internal_impl::<u8>(33);
+        test_binary_l1_internal_impl::<u8>(65);
+        test_binary_l1_internal_impl::<u8>(3 * 129);
+        test_binary_l1_internal_impl::<u128>(3 * 129);
     }
 
-    fn test_binary_l1_internal_impl<TBitsStoreType: BitsStoreType>() {
+    fn test_binary_l1_internal_impl<TBitsStoreType: BitsStoreType>(vector_dim: usize) {
         let vectors_count = 128;
-        let vector_dim = 3 * 129;
 
         //let mut rng = rand::thread_rng();
         let mut rng = rand::rngs::StdRng::seed_from_u64(42);
@@ -349,13 +377,17 @@ mod tests {
 
     #[test]
     fn test_binary_l1_inverted_internal() {
-        test_binary_l1_inverted_internal_impl::<u8>();
-        test_binary_l1_inverted_internal_impl::<u128>();
+        test_binary_l1_inverted_internal_impl::<u8>(0);
+        test_binary_l1_inverted_internal_impl::<u8>(1);
+        test_binary_l1_inverted_internal_impl::<u8>(8);
+        test_binary_l1_inverted_internal_impl::<u8>(33);
+        test_binary_l1_inverted_internal_impl::<u8>(65);
+        test_binary_l1_inverted_internal_impl::<u8>(3 * 129);
+        test_binary_l1_inverted_internal_impl::<u128>(3 * 129);
     }
 
-    fn test_binary_l1_inverted_internal_impl<TBitsStoreType: BitsStoreType>() {
+    fn test_binary_l1_inverted_internal_impl<TBitsStoreType: BitsStoreType>(vector_dim: usize) {
         let vectors_count = 128;
-        let vector_dim = 3 * 129;
 
         //let mut rng = rand::thread_rng();
         let mut rng = rand::rngs::StdRng::seed_from_u64(42);
@@ -402,13 +434,17 @@ mod tests {
 
     #[test]
     fn test_binary_l2() {
-        test_binary_l2_impl::<u8>();
-        test_binary_l2_impl::<u128>();
+        test_binary_l2_impl::<u8>(0);
+        test_binary_l2_impl::<u8>(1);
+        test_binary_l2_impl::<u8>(8);
+        test_binary_l2_impl::<u8>(33);
+        test_binary_l2_impl::<u8>(65);
+        test_binary_l2_impl::<u8>(3 * 129);
+        test_binary_l2_impl::<u128>(3 * 129);
     }
 
-    fn test_binary_l2_impl<TBitsStoreType: BitsStoreType>() {
+    fn test_binary_l2_impl<TBitsStoreType: BitsStoreType>(vector_dim: usize) {
         let vectors_count = 128;
-        let vector_dim = 3 * 129;
 
         //let mut rng = rand::thread_rng();
         let mut rng = rand::rngs::StdRng::seed_from_u64(42);
@@ -458,13 +494,17 @@ mod tests {
 
     #[test]
     fn test_binary_l2_inverted() {
-        test_binary_l2_inverted_impl::<u8>();
-        test_binary_l2_inverted_impl::<u128>();
+        test_binary_l2_inverted_impl::<u8>(0);
+        test_binary_l2_inverted_impl::<u8>(1);
+        test_binary_l2_inverted_impl::<u8>(8);
+        test_binary_l2_inverted_impl::<u8>(33);
+        test_binary_l2_inverted_impl::<u8>(65);
+        test_binary_l2_inverted_impl::<u8>(3 * 129);
+        test_binary_l2_inverted_impl::<u128>(3 * 129);
     }
 
-    fn test_binary_l2_inverted_impl<TBitsStoreType: BitsStoreType>() {
+    fn test_binary_l2_inverted_impl<TBitsStoreType: BitsStoreType>(vector_dim: usize) {
         let vectors_count = 128;
-        let vector_dim = 3 * 129;
 
         //let mut rng = rand::thread_rng();
         let mut rng = rand::rngs::StdRng::seed_from_u64(42);
@@ -514,13 +554,17 @@ mod tests {
 
     #[test]
     fn test_binary_l2_internal() {
-        test_binary_l2_internal_impl::<u8>();
-        test_binary_l2_internal_impl::<u128>();
+        test_binary_l2_internal_impl::<u8>(0);
+        test_binary_l2_internal_impl::<u8>(1);
+        test_binary_l2_internal_impl::<u8>(8);
+        test_binary_l2_internal_impl::<u8>(33);
+        test_binary_l2_internal_impl::<u8>(65);
+        test_binary_l2_internal_impl::<u8>(3 * 129);
+        test_binary_l2_internal_impl::<u128>(3 * 129);
     }
 
-    fn test_binary_l2_internal_impl<TBitsStoreType: BitsStoreType>() {
+    fn test_binary_l2_internal_impl<TBitsStoreType: BitsStoreType>(vector_dim: usize) {
         let vectors_count = 128;
-        let vector_dim = 3 * 129;
 
         //let mut rng = rand::thread_rng();
         let mut rng = rand::rngs::StdRng::seed_from_u64(42);
@@ -567,13 +611,17 @@ mod tests {
 
     #[test]
     fn test_binary_l2_inverted_internal() {
-        test_binary_l2_inverted_internal_impl::<u8>();
-        test_binary_l2_inverted_internal_impl::<u128>();
+        test_binary_l2_inverted_internal_impl::<u8>(0);
+        test_binary_l2_inverted_internal_impl::<u8>(1);
+        test_binary_l2_inverted_internal_impl::<u8>(8);
+        test_binary_l2_inverted_internal_impl::<u8>(33);
+        test_binary_l2_inverted_internal_impl::<u8>(65);
+        test_binary_l2_inverted_internal_impl::<u8>(3 * 129);
+        test_binary_l2_inverted_internal_impl::<u128>(3 * 129);
     }
 
-    fn test_binary_l2_inverted_internal_impl<TBitsStoreType: BitsStoreType>() {
+    fn test_binary_l2_inverted_internal_impl<TBitsStoreType: BitsStoreType>(vector_dim: usize) {
         let vectors_count = 128;
-        let vector_dim = 3 * 129;
 
         //let mut rng = rand::thread_rng();
         let mut rng = rand::rngs::StdRng::seed_from_u64(42);


### PR DESCRIPTION
For multivector 128-dim alignment is too large. This PR introduces generic BQ storage with `u128` and `u8` alignment.

In `u128` case there are no any changes for backward compatibility. In `u8` case there is a flexible alignment: if `dim >= 128`, alignment is 128 and simd is optimized for 128-bit alignment (the same for 64 and 32).